### PR TITLE
Add allocator to all public functions to improve performance

### DIFF
--- a/examples/lookup.zig
+++ b/examples/lookup.zig
@@ -11,10 +11,12 @@ pub fn main() !void {
     defer _ = gpa.detectLeaks();
 
     var db = try maxminddb.Reader.open(allocator, db_path, max_db_size);
-    defer db.close();
+    defer db.close(allocator);
 
+    // Note, for better performance use arena allocator and reset it after calling lookup().
+    // You won't need to call city.deinit() in that case.
     const ip = try std.net.Address.parseIp("89.160.20.128", 0);
-    const city = try db.lookup(maxminddb.geoip2.City, &ip);
+    const city = try db.lookup(allocator, maxminddb.geoip2.City, &ip);
     defer city.deinit();
 
     var it = city.country.names.?.iterator();

--- a/examples/within.zig
+++ b/examples/within.zig
@@ -10,13 +10,13 @@ pub fn main() !void {
     const allocator = gpa.allocator();
     defer _ = gpa.detectLeaks();
 
-    var db = try maxminddb.Reader.open_mmap(allocator, db_path);
-    defer db.close();
+    var db = try maxminddb.Reader.mmap(allocator, db_path);
+    defer db.unmap();
 
     const network = maxminddb.Network{
         .ip = try std.net.Address.parseIp("0.0.0.0", 0),
     };
-    var it = try db.within(maxminddb.geolite2.City, network);
+    var it = try db.within(allocator, maxminddb.geolite2.City, network);
     defer it.deinit();
 
     var n: usize = 0;

--- a/src/maxminddb.zig
+++ b/src/maxminddb.zig
@@ -32,19 +32,20 @@ fn expectEqualMaps(
     }
 }
 
+const allocator = std.testing.allocator;
 const expectEqual = std.testing.expectEqual;
 const expectEqualStrings = std.testing.expectEqualStrings;
 const expectEqualDeep = std.testing.expectEqualDeep;
 
 test "GeoLite2 Country" {
-    var db = try Reader.open_mmap(
-        std.testing.allocator,
+    var db = try Reader.mmap(
+        allocator,
         "test-data/test-data/GeoLite2-Country-Test.mmdb",
     );
-    defer db.close();
+    defer db.unmap();
 
     const ip = try std.net.Address.parseIp("89.160.20.128", 0);
-    const got = try db.lookup(geolite2.Country, &ip);
+    const got = try db.lookup(allocator, geolite2.Country, &ip);
     defer got.deinit();
 
     try expectEqualStrings("EU", got.continent.code);
@@ -77,14 +78,14 @@ test "GeoLite2 Country" {
 }
 
 test "GeoLite2 City" {
-    var db = try Reader.open_mmap(
-        std.testing.allocator,
+    var db = try Reader.mmap(
+        allocator,
         "test-data/test-data/GeoLite2-City-Test.mmdb",
     );
-    defer db.close();
+    defer db.unmap();
 
     const ip = try std.net.Address.parseIp("89.160.20.128", 0);
-    const got = try db.lookup(geolite2.City, &ip);
+    const got = try db.lookup(allocator, geolite2.City, &ip);
     defer got.deinit();
 
     try expectEqual(2694762, got.city.geoname_id);
@@ -146,14 +147,14 @@ test "GeoLite2 City" {
 }
 
 test "GeoLite2 ASN" {
-    var db = try Reader.open_mmap(
-        std.testing.allocator,
+    var db = try Reader.mmap(
+        allocator,
         "test-data/test-data/GeoLite2-ASN-Test.mmdb",
     );
-    defer db.close();
+    defer db.unmap();
 
     const ip = try std.net.Address.parseIp("89.160.20.128", 0);
-    const got = try db.lookup(geolite2.ASN, &ip);
+    const got = try db.lookup(allocator, geolite2.ASN, &ip);
 
     const want = geolite2.ASN{
         .autonomous_system_number = 29518,
@@ -163,14 +164,14 @@ test "GeoLite2 ASN" {
 }
 
 test "GeoIP2 Country" {
-    var db = try Reader.open_mmap(
-        std.testing.allocator,
+    var db = try Reader.mmap(
+        allocator,
         "test-data/test-data/GeoIP2-Country-Test.mmdb",
     );
-    defer db.close();
+    defer db.unmap();
 
     const ip = try std.net.Address.parseIp("89.160.20.128", 0);
-    const got = try db.lookup(geoip2.Country, &ip);
+    const got = try db.lookup(allocator, geoip2.Country, &ip);
     defer got.deinit();
 
     try expectEqualStrings("EU", got.continent.code);
@@ -210,14 +211,14 @@ test "GeoIP2 Country" {
 }
 
 test "GeoIP2 City" {
-    var db = try Reader.open_mmap(
-        std.testing.allocator,
+    var db = try Reader.mmap(
+        allocator,
         "test-data/test-data/GeoIP2-City-Test.mmdb",
     );
-    defer db.close();
+    defer db.unmap();
 
     const ip = try std.net.Address.parseIp("89.160.20.128", 0);
-    const got = try db.lookup(geoip2.City, &ip);
+    const got = try db.lookup(allocator, geoip2.City, &ip);
     defer got.deinit();
 
     try expectEqual(2694762, got.city.geoname_id);
@@ -286,14 +287,14 @@ test "GeoIP2 City" {
 }
 
 test "GeoIP2 Enterprise" {
-    var db = try Reader.open_mmap(
-        std.testing.allocator,
+    var db = try Reader.mmap(
+        allocator,
         "test-data/test-data/GeoIP2-Enterprise-Test.mmdb",
     );
-    defer db.close();
+    defer db.unmap();
 
     const ip = try std.net.Address.parseIp("74.209.24.0", 0);
-    const got = try db.lookup(geoip2.Enterprise, &ip);
+    const got = try db.lookup(allocator, geoip2.Enterprise, &ip);
     defer got.deinit();
 
     try expectEqual(11, got.city.confidence);
@@ -380,14 +381,14 @@ test "GeoIP2 Enterprise" {
 }
 
 test "GeoIP2 ISP" {
-    var db = try Reader.open_mmap(
-        std.testing.allocator,
+    var db = try Reader.mmap(
+        allocator,
         "test-data/test-data/GeoIP2-ISP-Test.mmdb",
     );
-    defer db.close();
+    defer db.unmap();
 
     const ip = try std.net.Address.parseIp("89.160.20.112", 0);
-    const got = try db.lookup(geoip2.ISP, &ip);
+    const got = try db.lookup(allocator, geoip2.ISP, &ip);
 
     const want = geoip2.ISP{
         .autonomous_system_number = 29518,
@@ -399,14 +400,14 @@ test "GeoIP2 ISP" {
 }
 
 test "GeoIP2 Connection-Type" {
-    var db = try Reader.open_mmap(
-        std.testing.allocator,
+    var db = try Reader.mmap(
+        allocator,
         "test-data/test-data/GeoIP2-Connection-Type-Test.mmdb",
     );
-    defer db.close();
+    defer db.unmap();
 
     const ip = try std.net.Address.parseIp("96.1.20.112", 0);
-    const got = try db.lookup(geoip2.ConnectionType, &ip);
+    const got = try db.lookup(allocator, geoip2.ConnectionType, &ip);
 
     const want = geoip2.ConnectionType{
         .connection_type = "Cable/DSL",
@@ -415,14 +416,14 @@ test "GeoIP2 Connection-Type" {
 }
 
 test "GeoIP2 Anonymous-IP" {
-    var db = try Reader.open_mmap(
-        std.testing.allocator,
+    var db = try Reader.mmap(
+        allocator,
         "test-data/test-data/GeoIP2-Anonymous-IP-Test.mmdb",
     );
-    defer db.close();
+    defer db.unmap();
 
     const ip = try std.net.Address.parseIp("81.2.69.0", 0);
-    const got = try db.lookup(geoip2.AnonymousIP, &ip);
+    const got = try db.lookup(allocator, geoip2.AnonymousIP, &ip);
 
     const want = geoip2.AnonymousIP{
         .is_anonymous = true,
@@ -436,14 +437,14 @@ test "GeoIP2 Anonymous-IP" {
 }
 
 test "GeoIP2 DensityIncome" {
-    var db = try Reader.open_mmap(
-        std.testing.allocator,
+    var db = try Reader.mmap(
+        allocator,
         "test-data/test-data/GeoIP2-DensityIncome-Test.mmdb",
     );
-    defer db.close();
+    defer db.unmap();
 
     const ip = try std.net.Address.parseIp("5.83.124.123", 0);
-    const got = try db.lookup(geoip2.DensityIncome, &ip);
+    const got = try db.lookup(allocator, geoip2.DensityIncome, &ip);
 
     const want = geoip2.DensityIncome{
         .average_income = 32323,
@@ -453,14 +454,14 @@ test "GeoIP2 DensityIncome" {
 }
 
 test "GeoIP2 Domain" {
-    var db = try Reader.open_mmap(
-        std.testing.allocator,
+    var db = try Reader.mmap(
+        allocator,
         "test-data/test-data/GeoIP2-Domain-Test.mmdb",
     );
-    defer db.close();
+    defer db.unmap();
 
     const ip = try std.net.Address.parseIp("66.92.80.123", 0);
-    const got = try db.lookup(geoip2.Domain, &ip);
+    const got = try db.lookup(allocator, geoip2.Domain, &ip);
 
     const want = geoip2.Domain{
         .domain = "speakeasy.net",


### PR DESCRIPTION
This allowed to speed up lookups from ~85K/s to ~656K/s by reusing the arena allocator in the benchmark.

<details>

<summary>examples/benchmark.zig</summary>

```zig
// The benchmark is contributed by @oschwald.
const std = @import("std");
const maxminddb = @import("maxminddb");

const default_db_path: []const u8 = "GeoLite2-City.mmdb";
const default_num_lookups: u64 = 1_000_000;

pub fn main() !void {
    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
    const allocator = gpa.allocator();
    defer _ = gpa.detectLeaks();

    const args = try std.process.argsAlloc(allocator);
    defer std.process.argsFree(allocator, args);

    var db_path = default_db_path;
    var num_lookups = default_num_lookups;

    if (args.len > 1) {
        db_path = args[1];
    }
    if (args.len > 2) {
        num_lookups = try std.fmt.parseUnsigned(u64, args[2], 10);
    }

    std.debug.print("Benchmarking with:\n", .{});
    std.debug.print("  Database: {s}\n", .{db_path});
    std.debug.print("  Lookups:  {d}\n", .{num_lookups});
    std.debug.print("Opening database...\n", .{});

    var open_timer = try std.time.Timer.start();
    var db = try maxminddb.Reader.mmap(allocator, db_path);
    defer db.unmap();
    const open_time_ms = @as(f64, @floatFromInt(open_timer.read())) /
        @as(f64, @floatFromInt(std.time.ns_per_ms));
    std.debug.print("Database opened successfully in {d} ms. Type: {s}\n", .{
        open_time_ms,
        db.metadata.database_type,
    });

    var arena = std.heap.ArenaAllocator.init(allocator);
    defer arena.deinit();
    const arena_allocator = arena.allocator();

    std.debug.print("Starting benchmark...\n", .{});
    var timer = try std.time.Timer.start();
    var not_found_count: u64 = 0;
    var lookup_errors: u64 = 0;
    var ip_bytes: [4]u8 = undefined;

    for (0..num_lookups) |_| {
        std.crypto.random.bytes(&ip_bytes);
        const ip = std.net.Address.initIp4(ip_bytes, 0);

        _ = db.lookup(arena_allocator, maxminddb.geolite2.City, &ip) catch |err| {
            switch (err) {
                maxminddb.Error.AddressNotFound => {
                    not_found_count += 1;
                    continue;
                },
                else => {
                    std.debug.print("! Lookup error for IP {any}: {any}\n", .{ ip, err });
                    lookup_errors += 1;
                    continue;
                },
            }
        };
        _ = arena.reset(std.heap.ArenaAllocator.ResetMode.retain_capacity);
    }

    const elapsed_ns = timer.read();
    const elapsed_s = @as(f64, @floatFromInt(elapsed_ns)) /
        @as(f64, @floatFromInt(std.time.ns_per_s));
    const lookups_per_second = if (elapsed_s > 0)
        @as(f64, @floatFromInt(num_lookups)) / elapsed_s
    else
        0.0;
    const successful_lookups = num_lookups - not_found_count - lookup_errors;

    std.debug.print("\n--- Benchmark Finished ---\n", .{});
    std.debug.print("Total Lookups Attempted: {d}\n", .{num_lookups});
    std.debug.print("Successful Lookups:      {d}\n", .{successful_lookups});
    std.debug.print("IPs Not Found:           {d}\n", .{not_found_count});
    std.debug.print("Lookup Errors:           {d}\n", .{lookup_errors});
    std.debug.print("Elapsed Time:            {d} s\n", .{elapsed_s});
    std.debug.print("Lookups Per Second (avg):{d}\n", .{lookups_per_second});
}
```

</details>

Download `GeoLite2-City.mmdb`, add the benchmark to `build.zig`, and run `zig build example_benchmark -Doptimize=ReleaseFast`.

<details>

<summary>new</summary>

```sh
$ zig build example_benchmark -Doptimize=ReleaseFast
Benchmarking with:
  Database: GeoLite2-City.mmdb
  Lookups:  1000000
Opening database...
Database opened successfully in 0.04715 ms. Type: GeoLite2-City
Starting benchmark...

--- Benchmark Finished ---
Total Lookups Attempted: 1000000
Successful Lookups:      859161
IPs Not Found:           140839
Lookup Errors:           0
Elapsed Time:            1.523236271 s
Lookups Per Second (avg):656496.9722940638
```

</details>

<details>

<summary>old</summary>

```sh
zig build example_benchmark -Doptimize=ReleaseFast
Benchmarking with:
  Database: GeoLite2-City.mmdb
  Lookups:  1000000
Opening database...
Database opened successfully in 0.0484 ms. Type: GeoLite2-City
Starting benchmark...

--- Benchmark Finished ---
Total Lookups Attempted: 1000000
Successful Lookups:      859163
IPs Not Found:           140837
Lookup Errors:           0
Elapsed Time:            11.745747762 s
Lookups Per Second (avg):85137.19349867305
```

</details>