### PR TITLE
Refactor lookup() and within()

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Here is how you can decode `City.city` and `City.country` fields.
 ```zig
 // This gets us ~34% of performance gains, i.e., ~859K lookups per second.
 const fields = maxminddb.Fields.from(maxminddb.geolite2.City, &.{ "city", "country" });
-const city = try db.lookup(allocator, maxminddb.geolite2.City, &ip, .{ .only = fields });
+const city = try db.lookup(allocator, maxminddb.geolite2.City, ip, .{ .only = fields });
 ```
 
 Alternatively, define your own struct.
@@ -69,7 +69,7 @@ const MyCity = struct {
     } = .{},
 };
 
-const city = try db.lookup(allocator, MyCity, &ip, .{});
+const city = try db.lookup(allocator, MyCity, ip, .{});
 ```
 
 Decoding `MyCity` increases throughput by up to 60% (639,848 vs 1,025,477 lookups per second).

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Here is how you can decode `City.city` and `City.country` fields.
 ```zig
 // This gets us ~34% of performance gains, i.e., ~859K lookups per second.
 const fields = maxminddb.Fields.from(maxminddb.geolite2.City, &.{ "city", "country" });
-const city = try db.lookup(allocator, maxminddb.geolite2.City, ip, .{ .only = fields });
+const city = try db.lookup(allocator, maxminddb.geolite2.City, &ip, .{ .only = fields });
 ```
 
 Alternatively, define your own struct.
@@ -69,7 +69,7 @@ const MyCity = struct {
     } = .{},
 };
 
-const city = try db.lookup(allocator, MyCity, ip, .{});
+const city = try db.lookup(allocator, MyCity, &ip, .{});
 ```
 
 Decoding `MyCity` increases throughput by up to 60% (639,848 vs 1,025,477 lookups per second).

--- a/examples/benchmark.zig
+++ b/examples/benchmark.zig
@@ -50,19 +50,15 @@ pub fn main() !void {
         std.crypto.random.bytes(&ip_bytes);
         const ip = std.net.Address.initIp4(ip_bytes, 0);
 
-        _ = db.lookup(arena_allocator, maxminddb.geolite2.City, &ip, .{}) catch |err| {
-            switch (err) {
-                maxminddb.Error.AddressNotFound => {
-                    not_found_count += 1;
-                    continue;
-                },
-                else => {
-                    std.debug.print("! Lookup error for IP {any}: {any}\n", .{ ip, err });
-                    lookup_errors += 1;
-                    continue;
-                },
-            }
+        const result = db.lookup(arena_allocator, maxminddb.geolite2.City, ip, .{}) catch |err| {
+            std.debug.print("! Lookup error for IP {any}: {any}\n", .{ ip, err });
+            lookup_errors += 1;
+            continue;
         };
+        if (result == null) {
+            not_found_count += 1;
+            continue;
+        }
         _ = arena.reset(std.heap.ArenaAllocator.ResetMode.retain_capacity);
     }
 

--- a/examples/benchmark.zig
+++ b/examples/benchmark.zig
@@ -50,7 +50,7 @@ pub fn main() !void {
         std.crypto.random.bytes(&ip_bytes);
         const ip = std.net.Address.initIp4(ip_bytes, 0);
 
-        const result = db.lookup(arena_allocator, maxminddb.geolite2.City, &ip, .{}) catch |err| {
+        const result = db.lookup(arena_allocator, maxminddb.geolite2.City, ip, .{}) catch |err| {
             std.debug.print("! Lookup error for IP {any}: {any}\n", .{ ip, err });
             lookup_errors += 1;
             continue;

--- a/examples/benchmark.zig
+++ b/examples/benchmark.zig
@@ -50,7 +50,7 @@ pub fn main() !void {
         std.crypto.random.bytes(&ip_bytes);
         const ip = std.net.Address.initIp4(ip_bytes, 0);
 
-        const result = db.lookup(arena_allocator, maxminddb.geolite2.City, ip, .{}) catch |err| {
+        const result = db.lookup(arena_allocator, maxminddb.geolite2.City, &ip, .{}) catch |err| {
             std.debug.print("! Lookup error for IP {any}: {any}\n", .{ ip, err });
             lookup_errors += 1;
             continue;

--- a/examples/lookup.zig
+++ b/examples/lookup.zig
@@ -16,7 +16,7 @@ pub fn main() !void {
     // Note, for better performance use arena allocator and reset it after calling lookup().
     // You won't need to call city.deinit() in that case.
     const ip = try std.net.Address.parseIp("89.160.20.128", 0);
-    const city = try db.lookup(allocator, maxminddb.geoip2.City, &ip, .{}) orelse return;
+    const city = try db.lookup(allocator, maxminddb.geoip2.City, ip, .{}) orelse return;
     defer city.deinit();
 
     var it = city.value.country.names.?.iterator();

--- a/examples/lookup.zig
+++ b/examples/lookup.zig
@@ -16,10 +16,10 @@ pub fn main() !void {
     // Note, for better performance use arena allocator and reset it after calling lookup().
     // You won't need to call city.deinit() in that case.
     const ip = try std.net.Address.parseIp("89.160.20.128", 0);
-    const city = try db.lookup(allocator, maxminddb.geoip2.City, &ip, .{});
+    const city = try db.lookup(allocator, maxminddb.geoip2.City, ip, .{}) orelse return;
     defer city.deinit();
 
-    var it = city.country.names.?.iterator();
+    var it = city.value.country.names.?.iterator();
     while (it.next()) |kv| {
         std.debug.print("{s} = {s}\n", .{ kv.key_ptr.*, kv.value_ptr.* });
     }

--- a/examples/lookup.zig
+++ b/examples/lookup.zig
@@ -16,7 +16,7 @@ pub fn main() !void {
     // Note, for better performance use arena allocator and reset it after calling lookup().
     // You won't need to call city.deinit() in that case.
     const ip = try std.net.Address.parseIp("89.160.20.128", 0);
-    const city = try db.lookup(allocator, maxminddb.geoip2.City, ip, .{}) orelse return;
+    const city = try db.lookup(allocator, maxminddb.geoip2.City, &ip, .{}) orelse return;
     defer city.deinit();
 
     var it = city.value.country.names.?.iterator();

--- a/examples/within.zig
+++ b/examples/within.zig
@@ -19,35 +19,33 @@ pub fn main() !void {
     var it = try db.within(allocator, maxminddb.geolite2.City, network, .{});
     defer it.deinit();
 
-    // Note, for better performance use arena allocator and reset it after calling it.next().
-    // You won't need to call item.record.deinit() in that case.
+    // The iterator owns the values; each next() call invalidates the previous item.
     var n: usize = 0;
-    while (try it.next(allocator)) |item| {
-        defer item.record.deinit();
+    while (try it.next()) |item| {
 
-        const continent = item.record.continent.code;
-        const country = item.record.country.iso_code;
+        const continent = item.value.continent.code;
+        const country = item.value.country.iso_code;
         var city: []const u8 = "";
-        if (item.record.city.names) |city_names| {
+        if (item.value.city.names) |city_names| {
             city = city_names.get("en") orelse "";
         }
 
         if (city.len != 0) {
             std.debug.print("{f} {s}-{s}-{s}\n", .{
-                item.net,
+                item.network,
                 continent,
                 country,
                 city,
             });
         } else if (country.len != 0) {
             std.debug.print("{f} {s}-{s}\n", .{
-                item.net,
+                item.network,
                 continent,
                 country,
             });
         } else if (continent.len != 0) {
             std.debug.print("{f} {s}\n", .{
-                item.net,
+                item.network,
                 continent,
             });
         }

--- a/src/geoip2.zig
+++ b/src/geoip2.zig
@@ -8,13 +8,11 @@ pub const Names = std.StringArrayHashMap([]const u8);
 /// It can be used for geolocation at the country-level for analytics, content customization,
 /// or compliance use cases in territories that are not disputed.
 pub const Country = struct {
-    continent: Self.Continent,
-    country: Self.Country,
-    registered_country: Self.Country,
-    represented_country: Self.RepresentedCountry,
-    traits: Self.Traits,
-
-    _arena: std.heap.ArenaAllocator,
+    continent: Self.Continent = .{},
+    country: Self.Country = .{},
+    registered_country: Self.Country = .{},
+    represented_country: Self.RepresentedCountry = .{},
+    traits: Self.Traits = .{},
 
     const Self = @This();
     pub const Continent = struct {
@@ -38,24 +36,6 @@ pub const Country = struct {
     pub const Traits = struct {
         is_anycast: bool = false,
     };
-
-    pub fn init(allocator: std.mem.Allocator) Self {
-        const arena = std.heap.ArenaAllocator.init(allocator);
-
-        return .{
-            .continent = .{},
-            .country = .{},
-            .registered_country = .{},
-            .represented_country = .{},
-            .traits = .{},
-
-            ._arena = arena,
-        };
-    }
-
-    pub fn deinit(self: *const Self) void {
-        self._arena.deinit();
-    }
 };
 
 /// City represents a record in the GeoIP2-City database, for example,
@@ -63,17 +43,15 @@ pub const Country = struct {
 ///
 /// It can be used for geolocation down to the city or postal code for analytics and content customization.
 pub const City = struct {
-    city: Self.City,
-    continent: Country.Continent,
-    country: Country.Country,
-    location: Self.Location,
-    postal: Self.Postal,
-    registered_country: Country.Country,
-    represented_country: Country.RepresentedCountry,
+    city: Self.City = .{},
+    continent: Country.Continent = .{},
+    country: Country.Country = .{},
+    location: Self.Location = .{},
+    postal: Self.Postal = .{},
+    registered_country: Country.Country = .{},
+    represented_country: Country.RepresentedCountry = .{},
     subdivisions: ?std.ArrayList(Self.Subdivision) = null,
-    traits: Country.Traits,
-
-    _arena: std.heap.ArenaAllocator,
+    traits: Country.Traits = .{},
 
     const Self = @This();
     pub const City = struct {
@@ -95,27 +73,6 @@ pub const City = struct {
         iso_code: []const u8 = "",
         names: ?Names = null,
     };
-
-    pub fn init(allocator: std.mem.Allocator) Self {
-        const arena = std.heap.ArenaAllocator.init(allocator);
-
-        return .{
-            .city = .{},
-            .continent = .{},
-            .country = .{},
-            .location = .{},
-            .postal = .{},
-            .registered_country = .{},
-            .represented_country = .{},
-            .traits = .{},
-
-            ._arena = arena,
-        };
-    }
-
-    pub fn deinit(self: *const Self) void {
-        self._arena.deinit();
-    }
 };
 
 /// Enterprise represents a record in the GeoIP2-Enterprise database, for example,
@@ -123,17 +80,15 @@ pub const City = struct {
 /// Determine geolocation data such as country, region, state, city, ZIP/postal code,
 /// and additional intelligence such as confidence factors, ISP, domain, and connection type.
 pub const Enterprise = struct {
-    city: Self.City,
-    continent: Self.Continent,
-    country: Self.Country,
-    location: Self.Location,
-    postal: Self.Postal,
-    registered_country: Self.Country,
-    represented_country: Self.RepresentedCountry,
+    city: Self.City = .{},
+    continent: Self.Continent = .{},
+    country: Self.Country = .{},
+    location: Self.Location = .{},
+    postal: Self.Postal = .{},
+    registered_country: Self.Country = .{},
+    represented_country: Self.RepresentedCountry = .{},
     subdivisions: ?std.ArrayList(Self.Subdivision) = null,
-    traits: Self.Traits,
-
-    _arena: std.heap.ArenaAllocator,
+    traits: Self.Traits = .{},
 
     const Self = @This();
     pub const City = struct {
@@ -191,27 +146,6 @@ pub const Enterprise = struct {
         static_ip_score: f64 = 0,
         user_type: []const u8 = "",
     };
-
-    pub fn init(allocator: std.mem.Allocator) Self {
-        const arena = std.heap.ArenaAllocator.init(allocator);
-
-        return .{
-            .city = .{},
-            .continent = .{},
-            .country = .{},
-            .location = .{},
-            .postal = .{},
-            .registered_country = .{},
-            .represented_country = .{},
-            .traits = .{},
-
-            ._arena = arena,
-        };
-    }
-
-    pub fn deinit(self: *const Self) void {
-        self._arena.deinit();
-    }
 };
 
 /// ISP represents a record in the GeoIP2-ISP database, for example,

--- a/src/geolite2.zig
+++ b/src/geolite2.zig
@@ -7,12 +7,10 @@ pub const Names = std.StringArrayHashMap([]const u8);
 /// It can be used for geolocation at the country-level for analytics, content customization,
 /// or compliance use cases in territories that are not disputed.
 pub const Country = struct {
-    continent: Self.Continent,
-    country: Self.Country,
-    registered_country: Self.Country,
-    represented_country: Self.RepresentedCountry,
-
-    _arena: std.heap.ArenaAllocator,
+    continent: Self.Continent = .{},
+    country: Self.Country = .{},
+    registered_country: Self.Country = .{},
+    represented_country: Self.RepresentedCountry = .{},
 
     const Self = @This();
     pub const Continent = struct {
@@ -33,39 +31,20 @@ pub const Country = struct {
         names: ?Names = null,
         type: []const u8 = "",
     };
-
-    pub fn init(allocator: std.mem.Allocator) Self {
-        const arena = std.heap.ArenaAllocator.init(allocator);
-
-        return .{
-            .continent = .{},
-            .country = .{},
-            .registered_country = .{},
-            .represented_country = .{},
-
-            ._arena = arena,
-        };
-    }
-
-    pub fn deinit(self: *const Self) void {
-        self._arena.deinit();
-    }
 };
 
 /// City represents a record in the GeoLite2-City database, for example,
 /// https://github.com/maxmind/MaxMind-DB/blob/main/source-data/GeoLite2-City-Test.json.
 /// It can be used for geolocation down to the city or postal code for analytics and content customization.
 pub const City = struct {
-    city: Self.City,
-    continent: Country.Continent,
-    country: Country.Country,
-    location: Self.Location,
-    postal: Self.Postal,
-    registered_country: Country.Country,
-    represented_country: Country.RepresentedCountry,
+    city: Self.City = .{},
+    continent: Country.Continent = .{},
+    country: Country.Country = .{},
+    location: Self.Location = .{},
+    postal: Self.Postal = .{},
+    registered_country: Country.Country = .{},
+    represented_country: Country.RepresentedCountry = .{},
     subdivisions: ?std.ArrayList(Self.Subdivision) = null,
-
-    _arena: std.heap.ArenaAllocator,
 
     const Self = @This();
     pub const City = struct {
@@ -87,26 +66,6 @@ pub const City = struct {
         iso_code: []const u8 = "",
         names: ?Names = null,
     };
-
-    pub fn init(allocator: std.mem.Allocator) Self {
-        const arena = std.heap.ArenaAllocator.init(allocator);
-
-        return .{
-            .city = .{},
-            .continent = .{},
-            .country = .{},
-            .location = .{},
-            .postal = .{},
-            .registered_country = .{},
-            .represented_country = .{},
-
-            ._arena = arena,
-        };
-    }
-
-    pub fn deinit(self: *const Self) void {
-        self._arena.deinit();
-    }
 };
 
 /// Provides the autonomous system number and organization for IP addresses for analytics,

--- a/src/maxminddb.zig
+++ b/src/maxminddb.zig
@@ -139,7 +139,7 @@ test "GeoLite2 Country" {
     try expectEqual(DatabaseType.geolite_country, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("89.160.20.128", 0);
-    const got = (try db.lookup(allocator, geolite2.Country, &ip, .{})).?;
+    const got = (try db.lookup(allocator, geolite2.Country, ip, .{})).?;
     defer got.deinit();
 
     try expectEqualStrings("EU", got.value.continent.code);
@@ -172,7 +172,7 @@ test "GeoLite2 Country" {
 
     // Verify network masking for an IPv6 lookup.
     const ipv6 = try std.net.Address.parseIp("2001:218:ffff:ffff:ffff:ffff:ffff:ffff", 0);
-    const got_v6 = (try db.lookup(allocator, geolite2.Country, &ipv6, .{})).?;
+    const got_v6 = (try db.lookup(allocator, geolite2.Country, ipv6, .{})).?;
     defer got_v6.deinit();
 
     try expectEqualStrings("JP", got_v6.value.country.iso_code);
@@ -192,7 +192,7 @@ test "GeoLite2 City" {
     try expectEqual(DatabaseType.geolite_city, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("89.160.20.128", 0);
-    const got = (try db.lookup(allocator, geolite2.City, &ip, .{})).?;
+    const got = (try db.lookup(allocator, geolite2.City, ip, .{})).?;
     defer got.deinit();
 
     try expectEqual(2694762, got.value.city.geoname_id);
@@ -263,7 +263,7 @@ test "GeoLite2 ASN" {
     try expectEqual(DatabaseType.geolite_asn, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("89.160.20.128", 0);
-    const got = (try db.lookup(allocator, geolite2.ASN, &ip, .{})).?;
+    const got = (try db.lookup(allocator, geolite2.ASN, ip, .{})).?;
     defer got.deinit();
 
     const want = geolite2.ASN{
@@ -287,7 +287,7 @@ test "GeoIP2 Country" {
     try expectEqual(DatabaseType.geoip_country, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("89.160.20.128", 0);
-    const got = (try db.lookup(allocator, geoip2.Country, &ip, .{})).?;
+    const got = (try db.lookup(allocator, geoip2.Country, ip, .{})).?;
     defer got.deinit();
 
     try expectEqualStrings("EU", got.value.continent.code);
@@ -326,7 +326,7 @@ test "GeoIP2 Country" {
     );
 
     const ip2 = try std.net.Address.parseIp("214.1.1.0", 0);
-    const got2 = (try db.lookup(allocator, geoip2.Country, &ip2, .{})).?;
+    const got2 = (try db.lookup(allocator, geoip2.Country, ip2, .{})).?;
     defer got2.deinit();
 
     try expectEqual(true, got2.value.traits.is_anycast);
@@ -340,7 +340,7 @@ test "GeoIP2 Country RepresentedCountry" {
     defer db.unmap();
 
     const ip = try std.net.Address.parseIp("202.196.224.0", 0);
-    const got = (try db.lookup(allocator, geoip2.Country, &ip, .{})).?;
+    const got = (try db.lookup(allocator, geoip2.Country, ip, .{})).?;
     defer got.deinit();
 
     try expectEqualStrings("AS", got.value.continent.code);
@@ -367,7 +367,7 @@ test "GeoIP2 City" {
     try expectEqual(DatabaseType.geoip_city, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("89.160.20.128", 0);
-    const got = (try db.lookup(allocator, geoip2.City, &ip, .{})).?;
+    const got = (try db.lookup(allocator, geoip2.City, ip, .{})).?;
     defer got.deinit();
 
     try expectEqual(2694762, got.value.city.geoname_id);
@@ -435,7 +435,7 @@ test "GeoIP2 City" {
     );
 
     const ip2 = try std.net.Address.parseIp("214.1.1.0", 0);
-    const got2 = (try db.lookup(allocator, geoip2.City, &ip2, .{})).?;
+    const got2 = (try db.lookup(allocator, geoip2.City, ip2, .{})).?;
     defer got2.deinit();
 
     try expectEqual(true, got2.value.traits.is_anycast);
@@ -451,7 +451,7 @@ test "GeoIP2 Enterprise" {
     try expectEqual(DatabaseType.geoip_enterprise, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("74.209.24.0", 0);
-    const got = (try db.lookup(allocator, geoip2.Enterprise, &ip, .{})).?;
+    const got = (try db.lookup(allocator, geoip2.Enterprise, ip, .{})).?;
     defer got.deinit();
 
     try expectEqual(11, got.value.city.confidence);
@@ -537,7 +537,7 @@ test "GeoIP2 Enterprise" {
     );
 
     const ip2 = try std.net.Address.parseIp("214.1.1.0", 0);
-    const got2 = (try db.lookup(allocator, geoip2.Enterprise, &ip2, .{})).?;
+    const got2 = (try db.lookup(allocator, geoip2.Enterprise, ip2, .{})).?;
     defer got2.deinit();
 
     try expectEqual(true, got2.value.traits.is_anycast);
@@ -553,7 +553,7 @@ test "GeoIP2 ISP" {
     try expectEqual(DatabaseType.geoip_isp, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("149.101.100.0", 0);
-    const got = (try db.lookup(allocator, geoip2.ISP, &ip, .{})).?;
+    const got = (try db.lookup(allocator, geoip2.ISP, ip, .{})).?;
     defer got.deinit();
 
     const want = geoip2.ISP{
@@ -577,7 +577,7 @@ test "GeoIP2 Connection-Type" {
     try expectEqual(DatabaseType.geoip_connection_type, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("96.1.20.112", 0);
-    const got = (try db.lookup(allocator, geoip2.ConnectionType, &ip, .{})).?;
+    const got = (try db.lookup(allocator, geoip2.ConnectionType, ip, .{})).?;
     defer got.deinit();
 
     const want = geoip2.ConnectionType{
@@ -596,7 +596,7 @@ test "GeoIP2 Anonymous-IP" {
     try expectEqual(DatabaseType.geoip_anonymous_ip, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("81.2.69.0", 0);
-    const got = (try db.lookup(allocator, geoip2.AnonymousIP, &ip, .{})).?;
+    const got = (try db.lookup(allocator, geoip2.AnonymousIP, ip, .{})).?;
     defer got.deinit();
 
     const want = geoip2.AnonymousIP{
@@ -620,7 +620,7 @@ test "GeoIP Anonymous-Plus" {
     try expectEqual(DatabaseType.geoip_anonymous_plus, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("1.2.0.1", 0);
-    const got = (try db.lookup(allocator, geoip2.AnonymousPlus, &ip, .{})).?;
+    const got = (try db.lookup(allocator, geoip2.AnonymousPlus, ip, .{})).?;
     defer got.deinit();
 
     const want = geoip2.AnonymousPlus{
@@ -643,7 +643,7 @@ test "GeoIP2 DensityIncome" {
     try expectEqual(DatabaseType.geoip_densityincome, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("5.83.124.123", 0);
-    const got = (try db.lookup(allocator, geoip2.DensityIncome, &ip, .{})).?;
+    const got = (try db.lookup(allocator, geoip2.DensityIncome, ip, .{})).?;
     defer got.deinit();
 
     const want = geoip2.DensityIncome{
@@ -663,7 +663,7 @@ test "GeoIP2 Domain" {
     try expectEqual(DatabaseType.geoip_domain, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("66.92.80.123", 0);
-    const got = (try db.lookup(allocator, geoip2.Domain, &ip, .{})).?;
+    const got = (try db.lookup(allocator, geoip2.Domain, ip, .{})).?;
     defer got.deinit();
 
     const want = geoip2.Domain{
@@ -682,7 +682,7 @@ test "GeoIP2 IP-Risk" {
     try expectEqual(DatabaseType.geoip_ip_risk, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("6.1.2.1", 0);
-    const got = (try db.lookup(allocator, geoip2.IPRisk, &ip, .{})).?;
+    const got = (try db.lookup(allocator, geoip2.IPRisk, ip, .{})).?;
     defer got.deinit();
 
     const want = geoip2.IPRisk{
@@ -696,7 +696,7 @@ test "GeoIP2 IP-Risk" {
     try expectEqualDeep(want, got.value);
 
     const ip2 = try std.net.Address.parseIp("214.2.3.5", 0);
-    const got2 = (try db.lookup(allocator, geoip2.IPRisk, &ip2, .{})).?;
+    const got2 = (try db.lookup(allocator, geoip2.IPRisk, ip2, .{})).?;
     defer got2.deinit();
 
     const want2 = geoip2.IPRisk{
@@ -719,7 +719,7 @@ test "GeoIP2 Static-IP-Score" {
     try expectEqual(DatabaseType.geoip_static_ip_score, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("1.2.3.4", 0);
-    const got = (try db.lookup(allocator, geoip2.StaticIPScore, &ip, .{})).?;
+    const got = (try db.lookup(allocator, geoip2.StaticIPScore, ip, .{})).?;
     defer got.deinit();
 
     const want = geoip2.StaticIPScore{
@@ -738,7 +738,7 @@ test "GeoIP2 User-Count" {
     try expectEqual(DatabaseType.geoip_user_count, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("1.2.3.4", 0);
-    const got = (try db.lookup(allocator, geoip2.UserCount, &ip, .{})).?;
+    const got = (try db.lookup(allocator, geoip2.UserCount, ip, .{})).?;
     defer got.deinit();
 
     const want = geoip2.UserCount{
@@ -758,7 +758,7 @@ test "lookup with Fields filtering" {
     const ip = try std.net.Address.parseIp("89.160.20.128", 0);
 
     const fields = Fields.from(geolite2.City, &.{ "city", "country" });
-    const got = (try db.lookup(allocator, geolite2.City, &ip, .{ .only = fields })).?;
+    const got = (try db.lookup(allocator, geolite2.City, ip, .{ .only = fields })).?;
     defer got.deinit();
 
     // Filtered fields are decoded.
@@ -790,7 +790,7 @@ test "lookup with custom record" {
     };
 
     const ip = try std.net.Address.parseIp("89.160.20.128", 0);
-    const got = (try db.lookup(allocator, MyCity, &ip, .{})).?;
+    const got = (try db.lookup(allocator, MyCity, ip, .{})).?;
     defer got.deinit();
 
     try expectEqual(2694762, got.value.city.geoname_id);

--- a/src/maxminddb.zig
+++ b/src/maxminddb.zig
@@ -139,7 +139,7 @@ test "GeoLite2 Country" {
     try expectEqual(DatabaseType.geolite_country, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("89.160.20.128", 0);
-    const got = (try db.lookup(allocator, geolite2.Country, ip, .{})).?;
+    const got = (try db.lookup(allocator, geolite2.Country, &ip, .{})).?;
     defer got.deinit();
 
     try expectEqualStrings("EU", got.value.continent.code);
@@ -172,7 +172,7 @@ test "GeoLite2 Country" {
 
     // Verify network masking for an IPv6 lookup.
     const ipv6 = try std.net.Address.parseIp("2001:218:ffff:ffff:ffff:ffff:ffff:ffff", 0);
-    const got_v6 = (try db.lookup(allocator, geolite2.Country, ipv6, .{})).?;
+    const got_v6 = (try db.lookup(allocator, geolite2.Country, &ipv6, .{})).?;
     defer got_v6.deinit();
 
     try expectEqualStrings("JP", got_v6.value.country.iso_code);
@@ -192,7 +192,7 @@ test "GeoLite2 City" {
     try expectEqual(DatabaseType.geolite_city, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("89.160.20.128", 0);
-    const got = (try db.lookup(allocator, geolite2.City, ip, .{})).?;
+    const got = (try db.lookup(allocator, geolite2.City, &ip, .{})).?;
     defer got.deinit();
 
     try expectEqual(2694762, got.value.city.geoname_id);
@@ -263,7 +263,7 @@ test "GeoLite2 ASN" {
     try expectEqual(DatabaseType.geolite_asn, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("89.160.20.128", 0);
-    const got = (try db.lookup(allocator, geolite2.ASN, ip, .{})).?;
+    const got = (try db.lookup(allocator, geolite2.ASN, &ip, .{})).?;
     defer got.deinit();
 
     const want = geolite2.ASN{
@@ -287,7 +287,7 @@ test "GeoIP2 Country" {
     try expectEqual(DatabaseType.geoip_country, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("89.160.20.128", 0);
-    const got = (try db.lookup(allocator, geoip2.Country, ip, .{})).?;
+    const got = (try db.lookup(allocator, geoip2.Country, &ip, .{})).?;
     defer got.deinit();
 
     try expectEqualStrings("EU", got.value.continent.code);
@@ -326,7 +326,7 @@ test "GeoIP2 Country" {
     );
 
     const ip2 = try std.net.Address.parseIp("214.1.1.0", 0);
-    const got2 = (try db.lookup(allocator, geoip2.Country, ip2, .{})).?;
+    const got2 = (try db.lookup(allocator, geoip2.Country, &ip2, .{})).?;
     defer got2.deinit();
 
     try expectEqual(true, got2.value.traits.is_anycast);
@@ -340,7 +340,7 @@ test "GeoIP2 Country RepresentedCountry" {
     defer db.unmap();
 
     const ip = try std.net.Address.parseIp("202.196.224.0", 0);
-    const got = (try db.lookup(allocator, geoip2.Country, ip, .{})).?;
+    const got = (try db.lookup(allocator, geoip2.Country, &ip, .{})).?;
     defer got.deinit();
 
     try expectEqualStrings("AS", got.value.continent.code);
@@ -367,7 +367,7 @@ test "GeoIP2 City" {
     try expectEqual(DatabaseType.geoip_city, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("89.160.20.128", 0);
-    const got = (try db.lookup(allocator, geoip2.City, ip, .{})).?;
+    const got = (try db.lookup(allocator, geoip2.City, &ip, .{})).?;
     defer got.deinit();
 
     try expectEqual(2694762, got.value.city.geoname_id);
@@ -435,7 +435,7 @@ test "GeoIP2 City" {
     );
 
     const ip2 = try std.net.Address.parseIp("214.1.1.0", 0);
-    const got2 = (try db.lookup(allocator, geoip2.City, ip2, .{})).?;
+    const got2 = (try db.lookup(allocator, geoip2.City, &ip2, .{})).?;
     defer got2.deinit();
 
     try expectEqual(true, got2.value.traits.is_anycast);
@@ -451,7 +451,7 @@ test "GeoIP2 Enterprise" {
     try expectEqual(DatabaseType.geoip_enterprise, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("74.209.24.0", 0);
-    const got = (try db.lookup(allocator, geoip2.Enterprise, ip, .{})).?;
+    const got = (try db.lookup(allocator, geoip2.Enterprise, &ip, .{})).?;
     defer got.deinit();
 
     try expectEqual(11, got.value.city.confidence);
@@ -537,7 +537,7 @@ test "GeoIP2 Enterprise" {
     );
 
     const ip2 = try std.net.Address.parseIp("214.1.1.0", 0);
-    const got2 = (try db.lookup(allocator, geoip2.Enterprise, ip2, .{})).?;
+    const got2 = (try db.lookup(allocator, geoip2.Enterprise, &ip2, .{})).?;
     defer got2.deinit();
 
     try expectEqual(true, got2.value.traits.is_anycast);
@@ -553,7 +553,7 @@ test "GeoIP2 ISP" {
     try expectEqual(DatabaseType.geoip_isp, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("149.101.100.0", 0);
-    const got = (try db.lookup(allocator, geoip2.ISP, ip, .{})).?;
+    const got = (try db.lookup(allocator, geoip2.ISP, &ip, .{})).?;
     defer got.deinit();
 
     const want = geoip2.ISP{
@@ -577,7 +577,7 @@ test "GeoIP2 Connection-Type" {
     try expectEqual(DatabaseType.geoip_connection_type, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("96.1.20.112", 0);
-    const got = (try db.lookup(allocator, geoip2.ConnectionType, ip, .{})).?;
+    const got = (try db.lookup(allocator, geoip2.ConnectionType, &ip, .{})).?;
     defer got.deinit();
 
     const want = geoip2.ConnectionType{
@@ -596,7 +596,7 @@ test "GeoIP2 Anonymous-IP" {
     try expectEqual(DatabaseType.geoip_anonymous_ip, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("81.2.69.0", 0);
-    const got = (try db.lookup(allocator, geoip2.AnonymousIP, ip, .{})).?;
+    const got = (try db.lookup(allocator, geoip2.AnonymousIP, &ip, .{})).?;
     defer got.deinit();
 
     const want = geoip2.AnonymousIP{
@@ -620,7 +620,7 @@ test "GeoIP Anonymous-Plus" {
     try expectEqual(DatabaseType.geoip_anonymous_plus, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("1.2.0.1", 0);
-    const got = (try db.lookup(allocator, geoip2.AnonymousPlus, ip, .{})).?;
+    const got = (try db.lookup(allocator, geoip2.AnonymousPlus, &ip, .{})).?;
     defer got.deinit();
 
     const want = geoip2.AnonymousPlus{
@@ -643,7 +643,7 @@ test "GeoIP2 DensityIncome" {
     try expectEqual(DatabaseType.geoip_densityincome, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("5.83.124.123", 0);
-    const got = (try db.lookup(allocator, geoip2.DensityIncome, ip, .{})).?;
+    const got = (try db.lookup(allocator, geoip2.DensityIncome, &ip, .{})).?;
     defer got.deinit();
 
     const want = geoip2.DensityIncome{
@@ -663,7 +663,7 @@ test "GeoIP2 Domain" {
     try expectEqual(DatabaseType.geoip_domain, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("66.92.80.123", 0);
-    const got = (try db.lookup(allocator, geoip2.Domain, ip, .{})).?;
+    const got = (try db.lookup(allocator, geoip2.Domain, &ip, .{})).?;
     defer got.deinit();
 
     const want = geoip2.Domain{
@@ -682,7 +682,7 @@ test "GeoIP2 IP-Risk" {
     try expectEqual(DatabaseType.geoip_ip_risk, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("6.1.2.1", 0);
-    const got = (try db.lookup(allocator, geoip2.IPRisk, ip, .{})).?;
+    const got = (try db.lookup(allocator, geoip2.IPRisk, &ip, .{})).?;
     defer got.deinit();
 
     const want = geoip2.IPRisk{
@@ -696,7 +696,7 @@ test "GeoIP2 IP-Risk" {
     try expectEqualDeep(want, got.value);
 
     const ip2 = try std.net.Address.parseIp("214.2.3.5", 0);
-    const got2 = (try db.lookup(allocator, geoip2.IPRisk, ip2, .{})).?;
+    const got2 = (try db.lookup(allocator, geoip2.IPRisk, &ip2, .{})).?;
     defer got2.deinit();
 
     const want2 = geoip2.IPRisk{
@@ -719,7 +719,7 @@ test "GeoIP2 Static-IP-Score" {
     try expectEqual(DatabaseType.geoip_static_ip_score, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("1.2.3.4", 0);
-    const got = (try db.lookup(allocator, geoip2.StaticIPScore, ip, .{})).?;
+    const got = (try db.lookup(allocator, geoip2.StaticIPScore, &ip, .{})).?;
     defer got.deinit();
 
     const want = geoip2.StaticIPScore{
@@ -738,7 +738,7 @@ test "GeoIP2 User-Count" {
     try expectEqual(DatabaseType.geoip_user_count, DatabaseType.new(db.metadata.database_type));
 
     const ip = try std.net.Address.parseIp("1.2.3.4", 0);
-    const got = (try db.lookup(allocator, geoip2.UserCount, ip, .{})).?;
+    const got = (try db.lookup(allocator, geoip2.UserCount, &ip, .{})).?;
     defer got.deinit();
 
     const want = geoip2.UserCount{
@@ -758,7 +758,7 @@ test "lookup with Fields filtering" {
     const ip = try std.net.Address.parseIp("89.160.20.128", 0);
 
     const fields = Fields.from(geolite2.City, &.{ "city", "country" });
-    const got = (try db.lookup(allocator, geolite2.City, ip, .{ .only = fields })).?;
+    const got = (try db.lookup(allocator, geolite2.City, &ip, .{ .only = fields })).?;
     defer got.deinit();
 
     // Filtered fields are decoded.
@@ -790,7 +790,7 @@ test "lookup with custom record" {
     };
 
     const ip = try std.net.Address.parseIp("89.160.20.128", 0);
-    const got = (try db.lookup(allocator, MyCity, ip, .{})).?;
+    const got = (try db.lookup(allocator, MyCity, &ip, .{})).?;
     defer got.deinit();
 
     try expectEqual(2694762, got.value.city.geoname_id);

--- a/src/net.zig
+++ b/src/net.zig
@@ -266,34 +266,3 @@ test "IP.mask" {
         try std.testing.expectEqualStrings(tc.want, got);
     }
 }
-
-// Converts an IP address into bytes slice, e.g., IPv6 address 1000:0ac3:22a2:0000:0000:4b3c:0504:1234
-// is converted into [16 0 10 195 34 162 0 0 0 0 75 60 5 4 18 52].
-pub fn ipToBytes(address: *const std.net.Address) []const u8 {
-    return switch (address.any.family) {
-        std.posix.AF.INET => std.mem.asBytes(&address.in.sa.addr),
-        std.posix.AF.INET6 => &address.in6.sa.addr,
-        else => unreachable,
-    };
-}
-
-test "ipToBytes" {
-    const tests = [_]struct {
-        addr: []const u8,
-        want: []const u8,
-    }{
-        .{
-            .addr = "89.160.20.128",
-            .want = &.{ 89, 160, 20, 128 },
-        },
-        .{
-            .addr = "1000:0ac3:22a2:0000:0000:4b3c:0504:1234",
-            .want = &.{ 16, 0, 10, 195, 34, 162, 0, 0, 0, 0, 75, 60, 5, 4, 18, 52 },
-        },
-    };
-
-    for (tests) |tc| {
-        const addr = try std.net.Address.parseIp(tc.addr, 0);
-        try std.testing.expectEqualStrings(tc.want, ipToBytes(&addr));
-    }
-}

--- a/src/net.zig
+++ b/src/net.zig
@@ -144,6 +144,34 @@ pub const IP = union(enum) {
         };
     }
 
+    /// Zeros out bits after prefix_len.
+    pub fn mask(self: IP, prefix_len: usize) IP {
+        return switch (self) {
+            .v4 => |b| {
+                // Combines IP bytes into a big-endian u32, e.g.,
+                // 89.160.20.128 = 89 << 24 | 160 << 16 | 20 << 8 | 128
+                const ipAsNumber = std.mem.readInt(u32, &b, .big);
+                const ones: u32 = std.math.maxInt(u32);
+                const bitmask = if (prefix_len == 0) 0 else ones << @intCast(32 - prefix_len);
+
+                var out: [4]u8 = undefined;
+                std.mem.writeInt(u32, &out, ipAsNumber & bitmask, .big);
+
+                return .{ .v4 = out };
+            },
+            .v6 => |b| {
+                const ipAsNumber = std.mem.readInt(u128, &b, .big);
+                const ones: u128 = std.math.maxInt(u128);
+                const bitmask = if (prefix_len == 0) 0 else ones << @intCast(128 - prefix_len);
+
+                var out: [16]u8 = undefined;
+                std.mem.writeInt(u128, &out, ipAsNumber & bitmask, .big);
+
+                return .{ .v6 = out };
+            },
+        };
+    }
+
     pub fn network(self: IP, prefix_len: usize) Network {
         return switch (self) {
             .v4 => |b| .{
@@ -167,6 +195,77 @@ pub const IP = union(enum) {
         };
     }
 };
+
+test "IP.mask" {
+    const tests = [_]struct {
+        addr: []const u8,
+        prefix_len: usize,
+        want: []const u8,
+    }{
+        // IPv4 partial byte boundary.
+        .{
+            .addr = "89.160.20.128",
+            .prefix_len = 17,
+            .want = "89.160.0.0/17",
+        },
+        // IPv4 byte boundaries.
+        .{
+            .addr = "89.160.20.128",
+            .prefix_len = 8,
+            .want = "89.0.0.0/8",
+        },
+        .{
+            .addr = "89.160.20.128",
+            .prefix_len = 24,
+            .want = "89.160.20.0/24",
+        },
+        // IPv4 zero prefix (all bits masked).
+        .{
+            .addr = "89.160.20.128",
+            .prefix_len = 0,
+            .want = "0.0.0.0/0",
+        },
+        // IPv4 full prefix (no bits masked).
+        .{
+            .addr = "89.160.20.128",
+            .prefix_len = 32,
+            .want = "89.160.20.128/32",
+        },
+        // IPv6 byte boundary.
+        .{
+            .addr = "2001:218:ffff:ffff:ffff:ffff:ffff:ffff",
+            .prefix_len = 32,
+            .want = "2001:0218:0000:0000:0000:0000:0000:0000/32",
+        },
+        // IPv6 partial byte boundary: /28 keeps top 4 bits of byte 3.
+        .{
+            .addr = "2a02:ffff::",
+            .prefix_len = 28,
+            .want = "2a02:fff0:0000:0000:0000:0000:0000:0000/28",
+        },
+        // IPv6 zero prefix.
+        .{
+            .addr = "2001:218:ffff:ffff:ffff:ffff:ffff:ffff",
+            .prefix_len = 0,
+            .want = "0000:0000:0000:0000:0000:0000:0000:0000/0",
+        },
+        // IPv6 full prefix (no bits masked).
+        .{
+            .addr = "2001:218:ffff:ffff:ffff:ffff:ffff:ffff",
+            .prefix_len = 128,
+            .want = "2001:0218:ffff:ffff:ffff:ffff:ffff:ffff/128",
+        },
+    };
+
+    var buf: [64]u8 = undefined;
+    for (tests) |tc| {
+        const ip = IP.init(try std.net.Address.parseIp(tc.addr, 0));
+        const masked = ip.mask(tc.prefix_len).network(tc.prefix_len);
+        const got = try std.fmt.bufPrint(&buf, "{f}", .{masked});
+
+        try std.testing.expectEqualStrings(tc.want, got);
+    }
+}
 
 // Converts an IP address into bytes slice, e.g., IPv6 address 1000:0ac3:22a2:0000:0000:4b3c:0504:1234
 // is converted into [16 0 10 195 34 162 0 0 0 0 75 60 5 4 18 52].

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -137,10 +137,10 @@ pub const Reader = struct {
         self: *Reader,
         allocator: std.mem.Allocator,
         T: type,
-        address: std.net.Address,
+        address: *const std.net.Address,
         options: Options,
     ) !?Result(T) {
-        const ip_bytes = net.ipToBytes(&address);
+        const ip_bytes = net.ipToBytes(address);
         const pointer, const prefix_len = try self.findAddressInTree(ip_bytes);
         if (pointer == 0) {
             return null;
@@ -156,7 +156,7 @@ pub const Reader = struct {
         );
 
         return .{
-            .network = net.IP.init(address).mask(prefix_len).network(prefix_len),
+            .network = net.IP.init(address.*).mask(prefix_len).network(prefix_len),
             .value = value,
             .arena = arena,
         };

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -7,7 +7,6 @@ pub const ReadError = error{
     MetadataStartNotFound,
     InvalidTreeNode,
     CorruptedTree,
-    AddressNotFound,
     UnknownRecordSize,
     InvalidPrefixLen,
 };
@@ -26,20 +25,6 @@ pub const Metadata = struct {
     languages: ?std.ArrayList([]const u8) = null,
     node_count: u32 = 0,
     record_size: u16 = 0,
-
-    _arena: std.heap.ArenaAllocator,
-
-    pub fn init(allocator: std.mem.Allocator) Metadata {
-        const arena = std.heap.ArenaAllocator.init(allocator);
-
-        return .{
-            ._arena = arena,
-        };
-    }
-
-    pub fn deinit(self: *const Metadata) void {
-        self._arena.deinit();
-    }
 };
 
 const data_section_separator_size = 16;
@@ -54,6 +39,7 @@ pub const Reader = struct {
     offset: usize,
     ipv4_start: usize,
     metadata: Metadata,
+    metadata_arena: std.heap.ArenaAllocator,
 
     // Loads a MaxMind DB file into memory.
     pub fn open(allocator: std.mem.Allocator, path: []const u8, max_db_size: usize) !Reader {
@@ -63,15 +49,9 @@ pub const Reader = struct {
         const src = try f.readToEndAlloc(allocator, max_db_size);
         errdefer allocator.free(src);
 
-        // Decode database metadata which is stored as a separate data section,
-        // see https://maxmind.github.io/MaxMind-DB/#database-metadata.
-        const metadata_start = try findMetadataStart(src);
-        var d = decoder.Decoder{
-            .src = src[metadata_start..],
-            .offset = 0,
-        };
-        const metadata = try d.decodeRecord(allocator, Metadata, null);
-        errdefer metadata.deinit();
+        var metadata_arena = std.heap.ArenaAllocator.init(allocator);
+        errdefer metadata_arena.deinit();
+        const metadata = try decodeMetadata(metadata_arena.allocator(), src);
 
         const search_tree_size = try std.math.mul(
             usize,
@@ -89,6 +69,7 @@ pub const Reader = struct {
             .offset = data_offset,
             .ipv4_start = 0,
             .metadata = metadata,
+            .metadata_arena = metadata_arena,
         };
 
         r.ipv4_start = try r.findIPv4Start();
@@ -100,7 +81,7 @@ pub const Reader = struct {
     // From this point all the DB records are unusable because their fields were backed by the same memory.
     // Note, the records still have to be deinited since they might contain arrays or maps.
     pub fn close(self: *Reader, allocator: std.mem.Allocator) void {
-        self.metadata.deinit();
+        self.metadata_arena.deinit();
         allocator.free(self.src);
     }
 
@@ -112,15 +93,9 @@ pub const Reader = struct {
         const src = try memorymap.map(f);
         errdefer memorymap.unmap(src);
 
-        // Decode database metadata which is stored as a separate data section,
-        // see https://maxmind.github.io/MaxMind-DB/#database-metadata.
-        const metadata_start = try findMetadataStart(src);
-        var d = decoder.Decoder{
-            .src = src[metadata_start..],
-            .offset = 0,
-        };
-        const metadata = try d.decodeRecord(allocator, Metadata, null);
-        errdefer metadata.deinit();
+        var metadata_arena = std.heap.ArenaAllocator.init(allocator);
+        errdefer metadata_arena.deinit();
+        const metadata = try decodeMetadata(metadata_arena.allocator(), src);
 
         const search_tree_size = try std.math.mul(
             usize,
@@ -138,6 +113,7 @@ pub const Reader = struct {
             .offset = data_offset,
             .ipv4_start = 0,
             .metadata = metadata,
+            .metadata_arena = metadata_arena,
         };
 
         r.ipv4_start = try r.findIPv4Start();
@@ -149,27 +125,41 @@ pub const Reader = struct {
     // From this point all the DB records are unusable because their fields were backed by the same memory.
     // Note, the records still have to be deinited since they might contain arrays or maps.
     pub fn unmap(self: *Reader) void {
-        self.metadata.deinit();
+        self.metadata_arena.deinit();
 
         memorymap.unmap(self.src);
         self.mapped_file.?.close();
     }
 
-    // Looks up a record by an IP address.
+    // Looks up a value by an IP address.
+    // The returned Result owns an arena with all decoded allocations.
     pub fn lookup(
         self: *Reader,
         allocator: std.mem.Allocator,
         T: type,
-        address: *const std.net.Address,
+        address: std.net.Address,
         options: Options,
-    ) !T {
-        const ip_bytes = net.ipToBytes(address);
-        const pointer, _ = try self.findAddressInTree(ip_bytes);
+    ) !?Result(T) {
+        const ip_bytes = net.ipToBytes(&address);
+        const pointer, const prefix_len = try self.findAddressInTree(ip_bytes);
         if (pointer == 0) {
-            return ReadError.AddressNotFound;
+            return null;
         }
 
-        return try self.resolveDataPointerAndDecode(allocator, T, pointer, options.only);
+        var arena = std.heap.ArenaAllocator.init(allocator);
+        errdefer arena.deinit();
+        const value = try self.resolveDataPointerAndDecode(
+            arena.allocator(),
+            T,
+            pointer,
+            options.only,
+        );
+
+        return .{
+            .network = net.IP.init(address).mask(prefix_len).network(prefix_len),
+            .value = value,
+            .arena = arena,
+        };
     }
 
     // Iterates over blocks of IP networks.
@@ -224,8 +214,22 @@ pub const Reader = struct {
             .node_count = node_count,
             .stack = stack,
             .allocator = allocator,
+            .arena = std.heap.ArenaAllocator.init(allocator),
             .fields = options.only,
         };
+    }
+
+    // Decodes database metadata which is stored as a separate data section,
+    // see https://maxmind.github.io/MaxMind-DB/#database-metadata.
+    fn decodeMetadata(allocator: std.mem.Allocator, src: []const u8) !Metadata {
+        const metadata_start = try findMetadataStart(src);
+
+        var d = decoder.Decoder{
+            .src = src[metadata_start..],
+            .offset = 0,
+        };
+
+        return try d.decodeRecord(allocator, Metadata, null);
     }
 
     fn resolveDataPointerAndDecode(
@@ -353,6 +357,20 @@ pub const Reader = struct {
     }
 };
 
+/// Result wraps a decoded value with an arena that owns all its allocations.
+/// Use deinit() to free the result's memory, or skip it when using an outer arena.
+pub fn Result(comptime T: type) type {
+    return struct {
+        network: net.Network,
+        value: T,
+        arena: std.heap.ArenaAllocator,
+
+        pub fn deinit(self: @This()) void {
+            self.arena.deinit();
+        }
+    };
+}
+
 const WithinNode = struct {
     ip_bytes: net.IP,
     prefix_len: usize,
@@ -365,16 +383,19 @@ pub fn Iterator(T: type) type {
         node_count: usize,
         stack: std.ArrayList(WithinNode),
         allocator: std.mem.Allocator,
+        arena: std.heap.ArenaAllocator,
         fields: ?decoder.Fields,
 
         const Self = @This();
 
         pub const Item = struct {
-            net: net.Network,
-            record: T,
+            network: net.Network,
+            value: T,
         };
 
-        pub fn next(self: *Self, allocator: std.mem.Allocator) !?Item {
+        /// Returns the next network and its value.
+        /// The iterator owns the value; each call invalidates the previous Item.
+        pub fn next(self: *Self) !?Item {
             while (self.stack.pop()) |current| {
                 const reader = self.reader;
                 const bit_count = current.ip_bytes.bitCount();
@@ -392,16 +413,18 @@ pub fn Iterator(T: type) type {
                 if (current.node > self.node_count) {
                     const ip_net = current.ip_bytes.network(current.prefix_len);
 
-                    const record = try reader.resolveDataPointerAndDecode(
-                        allocator,
+                    _ = self.arena.reset(.retain_capacity);
+
+                    const value = try reader.resolveDataPointerAndDecode(
+                        self.arena.allocator(),
                         T,
                         current.node,
                         self.fields,
                     );
 
                     return Item{
-                        .net = ip_net,
-                        .record = record,
+                        .network = ip_net,
+                        .value = value,
                     };
                 } else if (current.node < self.node_count) {
                     // In order traversal of the children on the right (1-bit).
@@ -436,6 +459,7 @@ pub fn Iterator(T: type) type {
         }
 
         pub fn deinit(self: *Self) void {
+            self.arena.deinit();
             self.stack.deinit(self.allocator);
         }
     };

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -137,10 +137,10 @@ pub const Reader = struct {
         self: *Reader,
         allocator: std.mem.Allocator,
         T: type,
-        address: *const std.net.Address,
+        address: std.net.Address,
         options: Options,
     ) !?Result(T) {
-        const ip = net.IP.init(address.*);
+        const ip = net.IP.init(address);
         const pointer, const prefix_len = try self.findAddressInTree(ip);
         if (pointer == 0) {
             return null;


### PR DESCRIPTION
`lookup()` signature changed:

- expects address value instead of a pointer
- returns `Result` wrapper to manage memory
- returns `null` instead of `AddressNotFound` error to be consistent with Rust implementation
- returns network as part of `Result.network`

`within` iterator still returns structs directly, e.g., City/Country,  but they're destroyed after `it.next()` call (iterator owns their memory).

All geolite2 and geoip2 structs no longer have `_arena`, `init()` and `deinit()`.
`Metadata` also dropped them, now `Reader` owns its memory.