### PR TITLE
API redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,44 +43,29 @@ exe.root_module.addImport("maxminddb", mmdb.module("maxminddb"));
 
 See [examples](./examples/).
 
-## Suggestions
+## Usage
 
-Build the IPv4 index to speed up lookups with `.ipv4_index_first_n_bits` if you have a long-lived `Reader`.
-The recommended value is 16 (~320KB fits L2 cache, ~1-4ms to build when warm
-and ~10ms-120ms due to page faults) or 12 (~20KB) for constrained devices.
+### Lookup
+
+Use `lookup()` for IP lookups in basic cases.
+It returns `Result` or null when the IP is not found or the record is empty.
+Each result owns an arena so you should call `result.deinit()` to free it.
 
 ```zig
-var db = try maxminddb.Reader.mmap(allocator, db_path, .{ .ipv4_index_first_n_bits = 16 });
+var db = try maxminddb.Reader.mmap(allocator, db_path, .{});
 defer db.close();
-```
 
-Each `lookup` result owns an arena with all decoded allocations.
-Call `deinit()` to free it or use `ArenaAllocator` with `reset()`,
-see [benchmarks](./benchmarks/lookup.zig).
-
-```zig
 if (try db.lookup(maxminddb.geolite2.City, allocator, ip, .{})) |result| {
     defer result.deinit();
     std.debug.print("{f} {s}\n", .{ result.network, result.value.city.names.?.get("en").? });
 }
-
-var arena = std.heap.ArenaAllocator.init(allocator);
-defer arena.deinit();
-
-const arena_allocator = arena.allocator();
-for (ips) |ip| {
-    if (try db.lookup(maxminddb.geolite2.City, arena_allocator, ip, .{})) |result| {
-        std.debug.print("{f} {s}\n", .{ result.network, result.value.city.names.?.get("en").? });
-    }
-
-    _ = arena.reset(.retain_capacity);
-}
 ```
 
-If you don't need all the fields, use `.only` to decode only the top-level fields you want.
+Use `.only` to decode only the top-level fields you need.
 
 ```zig
 const fields = &.{ "city", "country" };
+
 if (try db.lookup(maxminddb.geolite2.City, allocator, ip, .{ .only = fields })) |result| {
     defer result.deinit();
     std.debug.print("{f} {s}\n", .{ result.network, result.value.city.names.?.get("en").? });
@@ -107,48 +92,179 @@ if (try db.lookup(MyCity, allocator, ip, .{})) |result| {
 Use `any.Value` to decode any record without knowing the schema.
 
 ```zig
-if (try db.lookup(maxminddb.any.Value, allocator, ip, .{ .only = fields })) |result| {
+if (try db.lookup(maxminddb.any.Value, allocator, ip, .{})) |result| {
     defer result.deinit();
     // Formats as compact JSON.
     std.debug.print("{f}\n", .{result.value});
 }
 ```
 
-Use `lookupWithCache` to skip decoding when different IPs resolve to the same record.
-The cache owns decoded memory, so results don't need to be individually freed.
+Use `find()` and `Cache.decode()` for repeated lookups, e.g., in web services.
+The cache avoids re-decoding when different IPs resolve to the same record.
+No per-lookup arena allocation because values are owned by the cache.
+
+⚠️ Use a consistent `.only` field set with the same cache instance to avoid poisoning the cache.
 
 ```zig
-var cache = try maxminddb.Cache(maxminddb.geolite2.City).init(allocator, .{});
+var cache = try maxminddb.Cache(maxminddb.geolite2.City).init(allocator, .{ .size = 16 });
 defer cache.deinit();
 
-if (try db.lookupWithCache(maxminddb.geolite2.City, &cache, ip, .{})) |result| {
-    std.debug.print("{f} {s}\n", .{ result.network, result.value.city.names.?.get("en").? });
+const decode_options: maxminddb.Reader.DecodeOptions = .{
+    .only = &.{ "city", "country" },
+};
+
+for (ips) |ip| {
+    const entry = try db.find(ip, .{}) orelse continue;
+    const value = try cache.decode(&db, entry, decode_options);
+    std.debug.print("{f} {s}\n", .{ entry.network, value.city.names.?.get("en").? });
 }
 ```
 
-Use `find` to check if an IP exists without decoding or to separate tree traversal from decoding.
+Use `find()` to check if an IP exists without decoding.
 
 ```zig
-if (try db.find(ip)) |entry| {
-    if (try db.decode(maxminddb.geolite2.City, allocator, entry, .{})) |result| {
-        defer result.deinit();
-        std.debug.print("{s}\n", .{result.value.city.names.?.get("en").?});
-    }
+if (try db.find(ip, .{})) |entry| {
+    std.debug.print("found in {f}\n", .{entry.network});
 }
 ```
 
-Here are reference results on Apple M2 Pro (1M random IPv4 lookups against GeoLite2-City
-with `ipv4_index_first_n_bits = 16`):
+Build the IPv4 index to speed up lookups if you have a long-lived `Reader` with many lookups.
+It adds a one-time build cost (~1-4ms warm, ~10-120ms with page faults)
+and uses ~320KB at depth 16, or 12 (~20KB) for constrained devices.
+It's not worth creating an index for short-lived readers.
 
-| Type            | Default    | `.only`    | `Cache`    |
-|---              |---         |---         |---         |
-| `geolite2.City` | ~1,444,000 | ~1,519,000 | ~1,687,000 |
-| `MyCity`        | ~1,567,000 |            |            |
-| `any.Value`     | ~1,411,000 | ~1,534,000 |            |
+```zig
+var db = try maxminddb.Reader.mmap(allocator, db_path, .{ .ipv4_index_first_n_bits = 16 });
+defer db.close();
+```
+
+For repeated lookups with the same allocator, use `ArenaAllocator` with `reset()`
+to avoid per-lookup alloc/free.
+
+```zig
+var arena = std.heap.ArenaAllocator.init(allocator);
+defer arena.deinit();
+const arena_allocator = arena.allocator();
+
+for (ips) |ip| {
+    if (try db.lookup(maxminddb.geolite2.City, arena_allocator, ip, .{})) |result| {
+        std.debug.print("{f} {s}\n", .{ result.network, result.value.city.names.?.get("en").? });
+    }
+    _ = arena.reset(.retain_capacity);
+}
+```
+
+⚠️ Don't reset the arena if you use `Cache.init(arena_allocator)` or else
+the cached values will be corrupted.
+
+### Scan
+
+Use `scan()` to iterate over networks in the database.
+Each result owns an arena so you should call `deinit()` to free it.
+
+```zig
+var it = try db.scan(maxminddb.any.Value, allocator, maxminddb.Network.all_ipv6, .{});
+
+while (try it.next()) |item| {
+    defer item.deinit();
+    std.debug.print("{f} {f}\n", .{ item.network, item.value });
+}
+```
+
+Use `entries()` and `Cache.decode()` for faster scans, see [Benchmarks](#benchmarks) section.
+Adjacent networks often share the same record so the cache avoids re-decoding them.
+Same cache caveat applies, i.e., use a consistent `.only` field set.
+
+```zig
+var cache = try maxminddb.Cache(maxminddb.any.Value).init(allocator, .{});
+defer cache.deinit();
+
+var it = try db.entries(maxminddb.Network.all_ipv6, .{});
+
+while (try it.next()) |entry| {
+    const value = try cache.decode(&db, entry, .{});
+    std.debug.print("{f} {f}\n", .{ entry.network, value });
+}
+```
+
+## Benchmarks
+
+The impact of each optimization depends on the database:
+
+- Index benefits sparse databases most because tree traversal dominates.
+  Dense databases like City still benefit though.
+  Index does not help scans at all.
+- `.only` helps when decoding is the bottleneck, i.e., databases with large records and many fields.
+  Little effect on databases with tiny records.
+- `Cache` helps when many IPs resolve to the same record.
+  Databases with few unique records benefit most.
+  Databases with millions of unique records benefit least because
+  almost every lookup is a cache miss.
+  For scans, the cache hit rate is much higher because adjacent entries
+  in the tree often share the same record.
+- `Cache` + `.only`: `.only` helps on cache misses when decoding fewer fields.
+
+Here are reference results on Apple M2 Pro.
+
+### Lookup
+
+1M random IPv4 lookups in GeoLite2-City.
+
+| Optimization              | `geolite2.City` | `MyCity`   | `any.Value` |
+|---                        |---              |---         |---          |
+| Default                   | ~1,293,000      |            |             |
+| Index                     | ~1,454,000      | ~1,511,000 | ~1,438,000  |
+| Index + `.only`           | ~1,531,000      |            | ~1,528,000  |
+| Index + `Cache`           | ~1,650,000      |            |             |
+| Index + `Cache` + `.only` | ~1,792,000      |            |             |
+
+Index means `Reader.Options{ .ipv4_index_first_n_bits = 16 }`.
 
 <details>
 
-<summary>All fields vs filtered (geolite2.City)</summary>
+<summary>Default vs Index (geolite2.City)</summary>
+
+```sh
+$ for i in $(seq 1 10); do
+    zig build benchmark_lookup -Doptimize=ReleaseFast -- GeoLite2-City.mmdb 1000000 '' 0 \
+      2>&1 | grep 'Lookups Per Second'
+  done
+
+  echo '---'
+
+  for i in $(seq 1 10); do
+    zig build benchmark_lookup -Doptimize=ReleaseFast -- GeoLite2-City.mmdb 1000000 '' 16 \
+      2>&1 | grep 'Lookups Per Second'
+  done
+
+Lookups Per Second (avg):1288123.6986424406
+Lookups Per Second (avg):1297844.4971600326
+Lookups Per Second (avg):1299800.7833033653
+Lookups Per Second (avg):1289163.7206031256
+Lookups Per Second (avg):1296087.9427189995
+Lookups Per Second (avg):1293914.0954956787
+Lookups Per Second (avg):1304671.4413292515
+Lookups Per Second (avg):1259770.3727349874
+Lookups Per Second (avg):1299818.3136058154
+Lookups Per Second (avg):1304484.7981250943
+---
+Lookups Per Second (avg):1428547.0249066802
+Lookups Per Second (avg):1380507.1016736578
+Lookups Per Second (avg):1424615.0690083539
+Lookups Per Second (avg):1479872.0734649224
+Lookups Per Second (avg):1470581.8382631212
+Lookups Per Second (avg):1452131.834013217
+Lookups Per Second (avg):1441057.419112997
+Lookups Per Second (avg):1460678.0011842097
+Lookups Per Second (avg):1469818.5626422924
+Lookups Per Second (avg):1427603.971951151
+```
+
+</details>
+
+<details>
+
+<summary>Index vs Index + .only (geolite2.City)</summary>
 
 ```sh
 $ for i in $(seq 1 10); do
@@ -163,34 +279,34 @@ $ for i in $(seq 1 10); do
       2>&1 | grep 'Lookups Per Second'
   done
 
-Lookups Per Second (avg):1336834.7262872674
-Lookups Per Second (avg):1451391.9756166148
-Lookups Per Second (avg):1465245.0296734683
-Lookups Per Second (avg):1477075.9656476441
-Lookups Per Second (avg):1455251.2079883837
-Lookups Per Second (avg):1480748.4188786792
-Lookups Per Second (avg):1455594.8950616007
-Lookups Per Second (avg):1444548.4772946609
-Lookups Per Second (avg):1445186.5149623165
-Lookups Per Second (avg):1426811.8637979662
+Lookups Per Second (avg):1428547.0249066802
+Lookups Per Second (avg):1380507.1016736578
+Lookups Per Second (avg):1424615.0690083539
+Lookups Per Second (avg):1479872.0734649224
+Lookups Per Second (avg):1470581.8382631212
+Lookups Per Second (avg):1452131.834013217
+Lookups Per Second (avg):1441057.419112997
+Lookups Per Second (avg):1460678.0011842097
+Lookups Per Second (avg):1469818.5626422924
+Lookups Per Second (avg):1427603.971951151
 ---
-Lookups Per Second (avg):1519486.5596566636
-Lookups Per Second (avg):1529797.101878328
-Lookups Per Second (avg):1547355.7584052305
-Lookups Per Second (avg):1512456.4964197539
-Lookups Per Second (avg):1496866.3111260908
-Lookups Per Second (avg):1523768.1167895973
-Lookups Per Second (avg):1507465.5353845328
-Lookups Per Second (avg):1503804.060346153
-Lookups Per Second (avg):1526249.4879909921
-Lookups Per Second (avg):1526612.3841468173
+Lookups Per Second (avg):1480631.763363951
+Lookups Per Second (avg):1547402.0513766634
+Lookups Per Second (avg):1522023.2008449882
+Lookups Per Second (avg):1512118.8782619492
+Lookups Per Second (avg):1507072.3128425558
+Lookups Per Second (avg):1524512.3489753657
+Lookups Per Second (avg):1564611.0025010307
+Lookups Per Second (avg):1518824.4053660445
+Lookups Per Second (avg):1559368.5734912506
+Lookups Per Second (avg):1571173.0594097849
 ```
 
 </details>
 
 <details>
 
-<summary>geolite2.City with Cache</summary>
+<summary>Index + Cache (geolite2.City)</summary>
 
 ```sh
 $ for i in $(seq 1 10); do
@@ -198,23 +314,47 @@ $ for i in $(seq 1 10); do
       2>&1 | grep 'Lookups Per Second'
   done
 
-Lookups Per Second (avg):1667393.603034771
-Lookups Per Second (avg):1702172.2057832577
-Lookups Per Second (avg):1687919.0899495105
-Lookups Per Second (avg):1711950.6136486975
-Lookups Per Second (avg):1677534.2929947844
-Lookups Per Second (avg):1678256.5441289553
-Lookups Per Second (avg):1682461.3558984331
-Lookups Per Second (avg):1671664.48097093
-Lookups Per Second (avg):1679197.6793488073
-Lookups Per Second (avg):1711229.9465240643
+Lookups Per Second (avg):1621097.9412664056
+Lookups Per Second (avg):1643755.6794738034
+Lookups Per Second (avg):1689941.621422972
+Lookups Per Second (avg):1619515.4855034132
+Lookups Per Second (avg):1635409.8950475699
+Lookups Per Second (avg):1667425.4591913386
+Lookups Per Second (avg):1624120.681573548
+Lookups Per Second (avg):1663304.0203721477
+Lookups Per Second (avg):1669982.860181014
+Lookups Per Second (avg):1667252.0583156152
 ```
 
 </details>
 
 <details>
 
-<summary>MyCity</summary>
+<summary>Index + Cache + .only (geolite2.City)</summary>
+
+```sh
+$ for i in $(seq 1 10); do
+    zig build benchmark_lookup_cache -Doptimize=ReleaseFast -- GeoLite2-City.mmdb 1000000 city \
+      2>&1 | grep 'Lookups Per Second'
+  done
+
+Lookups Per Second (avg):1778201.5145052548
+Lookups Per Second (avg):1843785.5733650513
+Lookups Per Second (avg):1775074.2749654094
+Lookups Per Second (avg):1787008.1402384518
+Lookups Per Second (avg):1673250.9089935562
+Lookups Per Second (avg):1780556.2368656157
+Lookups Per Second (avg):1795938.4381684947
+Lookups Per Second (avg):1796003.7580157353
+Lookups Per Second (avg):1853067.3542248248
+Lookups Per Second (avg):1837493.7370404094
+```
+
+</details>
+
+<details>
+
+<summary>Index (MyCity)</summary>
 
 ```sh
 $ for i in $(seq 1 10); do
@@ -222,23 +362,23 @@ $ for i in $(seq 1 10); do
       2>&1 | grep 'Lookups Per Second'
   done
 
-Lookups Per Second (avg):1529492.242988903
-Lookups Per Second (avg):1569407.6398299362
-Lookups Per Second (avg):1582132.2414254
-Lookups Per Second (avg):1571155.8831846418
-Lookups Per Second (avg):1555105.2509851856
-Lookups Per Second (avg):1563462.4039402052
-Lookups Per Second (avg):1575683.5274174165
-Lookups Per Second (avg):1592775.9126053287
-Lookups Per Second (avg):1587157.672409466
-Lookups Per Second (avg):1547889.6749373637
+Lookups Per Second (avg):1538491.815980477
+Lookups Per Second (avg):1517054.8236260759
+Lookups Per Second (avg):1557013.2507370606
+Lookups Per Second (avg):1536283.169286917
+Lookups Per Second (avg):1493722.1650662713
+Lookups Per Second (avg):1422596.100204022
+Lookups Per Second (avg):1578921.6062375184
+Lookups Per Second (avg):1506038.555716555
+Lookups Per Second (avg):1446028.78250593
+Lookups Per Second (avg):1517982.1124964976
 ```
 
 </details>
 
 <details>
 
-<summary>All fields vs filtered (any.Value)</summary>
+<summary>Index vs Index + .only (any.Value)</summary>
 
 ```sh
 $ for i in $(seq 1 10); do
@@ -253,66 +393,45 @@ $ for i in $(seq 1 10); do
       2>&1 | grep 'Lookups Per Second'
   done
 
-Lookups Per Second (avg):1340746.319735149
-Lookups Per Second (avg):1401828.871364838
-Lookups Per Second (avg):1422839.8394335485
-Lookups Per Second (avg):1438347.4818876525
-Lookups Per Second (avg):1420334.8378589922
-Lookups Per Second (avg):1428544.4739779825
-Lookups Per Second (avg):1406831.3620695053
-Lookups Per Second (avg):1420446.979153165
-Lookups Per Second (avg):1436113.5894043539
-Lookups Per Second (avg):1391091.5316276387
+Lookups Per Second (avg):1349487.9036850187
+Lookups Per Second (avg):1474607.7166711385
+Lookups Per Second (avg):1450025.6791572636
+Lookups Per Second (avg):1393922.5795159582
+Lookups Per Second (avg):1445392.2657224636
+Lookups Per Second (avg):1434162.4432459075
+Lookups Per Second (avg):1445543.9211354603
+Lookups Per Second (avg):1444219.8956908425
+Lookups Per Second (avg):1419883.9356485484
+Lookups Per Second (avg):1417836.1303990977
 ---
-Lookups Per Second (avg):1537147.178300735
-Lookups Per Second (avg):1539823.9865696551
-Lookups Per Second (avg):1525064.0478860594
-Lookups Per Second (avg):1544661.1739143485
-Lookups Per Second (avg):1523803.9115671553
-Lookups Per Second (avg):1538574.5645160857
-Lookups Per Second (avg):1519627.0285774737
-Lookups Per Second (avg):1512507.58772119
-Lookups Per Second (avg):1547616.3846134257
-Lookups Per Second (avg):1555055.2749218142
+Lookups Per Second (avg):1465955.9223703041
+Lookups Per Second (avg):1555487.9502469338
+Lookups Per Second (avg):1535026.522234302
+Lookups Per Second (avg):1517282.513153197
+Lookups Per Second (avg):1538161.4005770471
+Lookups Per Second (avg):1566922.985338839
+Lookups Per Second (avg):1568882.0602355888
+Lookups Per Second (avg):1536738.9132451336
+Lookups Per Second (avg):1549521.6473272059
+Lookups Per Second (avg):1448953.6358135713
 ```
 
 </details>
 
-Use `scan` to iterate over all networks in the database.
+### Scan
 
-```zig
-var it = try db.scan(maxminddb.any.Value, allocator, maxminddb.Network.all_ipv6, .{});
+Full GeoLite2-City scan using `any.Value`.
 
-while (try it.next()) |item| {
-    defer item.deinit();
-    std.debug.print("{f} {f}\n", .{ item.network, item.value });
-}
-```
-
-Use `scanWithCache` to avoid re-decoding networks that share the same record.
-The cache owns decoded memory, so results don't need to be individually freed.
-
-```zig
-var cache = try maxminddb.Cache(maxminddb.any.Value).init(allocator, .{});
-defer cache.deinit();
-
-var it = try db.scanWithCache(maxminddb.any.Value, &cache, maxminddb.Network.all_ipv6, .{});
-
-while (try it.next()) |item| {
-    std.debug.print("{f} {f}\n", .{ item.network, item.value });
-}
-```
-
-Here are reference results on Apple M2 Pro (full GeoLite2-City scan using `any.Value`):
-
-| Mode    | Records/sec |
-|---      |---          |
-| Default | ~1,288,000  |
-| `Cache` | ~3,061,000  |
+| Optimization        | `any.Value` |
+|---                  |---          |
+| Default             | ~1,295,000  |
+| `.only`             | ~1,458,000  |
+| `Cache`             | ~2,455,000  |
+| `Cache` + `.only`   | ~3,463,000  |
 
 <details>
 
-<summary>no cache (any.Value)</summary>
+<summary>Default vs .only (scan)</summary>
 
 ```sh
 $ for i in $(seq 1 10); do
@@ -320,23 +439,41 @@ $ for i in $(seq 1 10); do
       2>&1 | grep 'Records Per Second'
   done
 
-Records Per Second: 1288290.740360951
-Records Per Second: 1297969.4219374093
-Records Per Second: 1294606.3597480278
-Records Per Second: 1292000.0442060304
-Records Per Second: 1291402.9663056156
-Records Per Second: 1283349.9530272684
-Records Per Second: 1285392.657595849
-Records Per Second: 1284616.7577796134
-Records Per Second: 1282453.2935413013
-Records Per Second: 1283224.1123905785
+  echo '---'
+
+  for i in $(seq 1 10); do
+    zig build benchmark_scan -Doptimize=ReleaseFast -- GeoLite2-City.mmdb city \
+      2>&1 | grep 'Records Per Second'
+  done
+
+Records Per Second: 1286608.969567542
+Records Per Second: 1295843.0532171922
+Records Per Second: 1299430.7275630098
+Records Per Second: 1293056.1891340162
+Records Per Second: 1297424.4160547797
+Records Per Second: 1299599.593210179
+Records Per Second: 1296055.3662371547
+Records Per Second: 1293770.8917179666
+Records Per Second: 1296683.084988625
+Records Per Second: 1294042.5025624551
+---
+Records Per Second: 1453867.3129307455
+Records Per Second: 1461263.840886964
+Records Per Second: 1457367.244735448
+Records Per Second: 1457043.3486106358
+Records Per Second: 1461137.9718384417
+Records Per Second: 1458449.0786374495
+Records Per Second: 1455565.253714005
+Records Per Second: 1460540.094927675
+Records Per Second: 1454875.141172453
+Records Per Second: 1458530.6343777399
 ```
 
 </details>
 
 <details>
 
-<summary>cache (any.Value)</summary>
+<summary>Cache vs Cache + .only (scan)</summary>
 
 ```sh
 $ for i in $(seq 1 10); do
@@ -344,16 +481,34 @@ $ for i in $(seq 1 10); do
       2>&1 | grep 'Records Per Second'
   done
 
-Records Per Second: 3028071.506344128
-Records Per Second: 3067492.3032345856
-Records Per Second: 3068284.064917464
-Records Per Second: 3064978.468652021
-Records Per Second: 3086129.8223793525
-Records Per Second: 3072366.3772443924
-Records Per Second: 3059010.4090477442
-Records Per Second: 3053284.447089802
-Records Per Second: 3057155.2096146354
-Records Per Second: 3052158.2348704967
+  echo '---'
+
+  for i in $(seq 1 10); do
+    zig build benchmark_scan_cache -Doptimize=ReleaseFast -- GeoLite2-City.mmdb city \
+      2>&1 | grep 'Records Per Second'
+  done
+
+Records Per Second: 2456181.6827736874
+Records Per Second: 2460551.0497955345
+Records Per Second: 2464874.3375610826
+Records Per Second: 2462940.773846509
+Records Per Second: 2448205.1643172107
+Records Per Second: 2462645.62772618
+Records Per Second: 2448077.631411299
+Records Per Second: 2454071.3112366917
+Records Per Second: 2441321.7258892707
+Records Per Second: 2449213.043913177
+---
+Records Per Second: 3458689.2169479122
+Records Per Second: 3460744.848789136
+Records Per Second: 3464104.521198864
+Records Per Second: 3470945.186361765
+Records Per Second: 3440523.702543425
+Records Per Second: 3448881.855919776
+Records Per Second: 3461577.9857890424
+Records Per Second: 3479900.251019196
+Records Per Second: 3472727.724310288
+Records Per Second: 3467312.0330495955
 ```
 
 </details>

--- a/benchmarks/inspect.zig
+++ b/benchmarks/inspect.zig
@@ -18,15 +18,8 @@ pub fn main() !void {
     if (args.len > 1) db_path = args[1];
     if (args.len > 2) num_lookups = try std.fmt.parseUnsigned(u64, args[2], 10);
     if (args.len > 3) {
-        var items: [max_mmdb_fields][]const u8 = undefined;
-
-        var it = std.mem.splitScalar(u8, args[3], ',');
-        var i: usize = 0;
-        while (it.next()) |part| : (i += 1) {
-            items[i] = part;
-        }
-
-        fields = items[0..i];
+        const f = try maxminddb.Fields(max_mmdb_fields).parse(args[3], ',');
+        fields = f.only();
     }
 
     std.debug.print("Benchmarking with:\n", .{});

--- a/benchmarks/lookup.zig
+++ b/benchmarks/lookup.zig
@@ -15,19 +15,14 @@ pub fn main() !void {
     var db_path: []const u8 = default_db_path;
     var num_lookups = default_num_lookups;
     var fields: ?[]const []const u8 = null;
+    var index_bits: u8 = 16;
     if (args.len > 1) db_path = args[1];
     if (args.len > 2) num_lookups = try std.fmt.parseUnsigned(u64, args[2], 10);
     if (args.len > 3) {
-        var items: [max_mmdb_fields][]const u8 = undefined;
-
-        var it = std.mem.splitScalar(u8, args[3], ',');
-        var i: usize = 0;
-        while (it.next()) |part| : (i += 1) {
-            items[i] = part;
-        }
-
-        fields = items[0..i];
+        const f = try maxminddb.Fields(max_mmdb_fields).parse(args[3], ',');
+        fields = f.only();
     }
+    if (args.len > 4) index_bits = try std.fmt.parseUnsigned(u8, args[4], 10);
 
     std.debug.print("Benchmarking with:\n", .{});
     std.debug.print("  Database: {s}\n", .{db_path});
@@ -35,7 +30,7 @@ pub fn main() !void {
     std.debug.print("Opening database...\n", .{});
 
     var open_timer = try std.time.Timer.start();
-    var db = try maxminddb.Reader.mmap(allocator, db_path, .{ .ipv4_index_first_n_bits = 16 });
+    var db = try maxminddb.Reader.mmap(allocator, db_path, .{ .ipv4_index_first_n_bits = index_bits });
     defer db.close();
     const open_time_ms = @as(f64, @floatFromInt(open_timer.read())) /
         @as(f64, @floatFromInt(std.time.ns_per_ms));

--- a/benchmarks/lookup_cache.zig
+++ b/benchmarks/lookup_cache.zig
@@ -17,15 +17,8 @@ pub fn main() !void {
     if (args.len > 1) db_path = args[1];
     if (args.len > 2) num_lookups = try std.fmt.parseUnsigned(u64, args[2], 10);
     if (args.len > 3) {
-        var items: [max_mmdb_fields][]const u8 = undefined;
-
-        var it = std.mem.splitScalar(u8, args[3], ',');
-        var i: usize = 0;
-        while (it.next()) |part| : (i += 1) {
-            items[i] = part;
-        }
-
-        fields = items[0..i];
+        const f = try maxminddb.Fields(max_mmdb_fields).parse(args[3], ',');
+        fields = f.only();
     }
 
     std.debug.print("Benchmarking with:\n", .{});
@@ -56,20 +49,20 @@ pub fn main() !void {
         std.crypto.random.bytes(&ip_bytes);
         const ip = std.net.Address.initIp4(ip_bytes, 0);
 
-        const result = db.lookupWithCache(
-            maxminddb.geolite2.City,
-            &cache,
-            ip,
-            .{ .only = fields },
-        ) catch |err| {
+        const entry = db.find(ip, .{}) catch |err| {
             std.debug.print("! Lookup error for IP {any}: {any}\n", .{ ip, err });
             lookup_errors += 1;
             continue;
         };
-        if (result == null) {
+        if (entry == null) {
             not_found_count += 1;
             continue;
         }
+        _ = cache.decode(&db, entry.?, .{ .only = fields }) catch |err| {
+            std.debug.print("! Decode error for IP {any}: {any}\n", .{ ip, err });
+            lookup_errors += 1;
+            continue;
+        };
     }
 
     const elapsed_ns = timer.read();

--- a/benchmarks/scan.zig
+++ b/benchmarks/scan.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const maxminddb = @import("maxminddb");
 
 const default_db_path: []const u8 = "GeoLite2-City.mmdb";
+const max_mmdb_fields = 32;
 
 pub fn main() !void {
     const allocator = std.heap.smp_allocator;
@@ -10,7 +11,12 @@ pub fn main() !void {
     defer std.process.argsFree(allocator, args);
 
     var db_path: []const u8 = default_db_path;
+    var fields: ?[]const []const u8 = null;
     if (args.len > 1) db_path = args[1];
+    if (args.len > 2) {
+        const f = try maxminddb.Fields(max_mmdb_fields).parse(args[2], ',');
+        fields = f.only();
+    }
 
     std.debug.print("Benchmarking with:\n", .{});
     std.debug.print("  Database: {s}\n", .{db_path});
@@ -34,7 +40,7 @@ pub fn main() !void {
     std.debug.print("Starting benchmark...\n", .{});
     var timer = try std.time.Timer.start();
 
-    var it = try db.scan(maxminddb.any.Value, allocator, network, .{});
+    var it = try db.scan(maxminddb.any.Value, allocator, network, .{ .only = fields });
 
     var n: usize = 0;
     while (try it.next()) |item| {

--- a/benchmarks/scan_cache.zig
+++ b/benchmarks/scan_cache.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const maxminddb = @import("maxminddb");
 
 const default_db_path: []const u8 = "GeoLite2-City.mmdb";
+const max_mmdb_fields = 32;
 
 pub fn main() !void {
     const allocator = std.heap.smp_allocator;
@@ -10,7 +11,12 @@ pub fn main() !void {
     defer std.process.argsFree(allocator, args);
 
     var db_path: []const u8 = default_db_path;
+    var fields: ?[]const []const u8 = null;
     if (args.len > 1) db_path = args[1];
+    if (args.len > 2) {
+        const f = try maxminddb.Fields(max_mmdb_fields).parse(args[2], ',');
+        fields = f.only();
+    }
 
     std.debug.print("Benchmarking with:\n", .{});
     std.debug.print("  Database: {s}\n", .{db_path});
@@ -37,15 +43,11 @@ pub fn main() !void {
     std.debug.print("Starting benchmark...\n", .{});
     var timer = try std.time.Timer.start();
 
-    var it = try db.scanWithCache(
-        maxminddb.any.Value,
-        &cache,
-        network,
-        .{},
-    );
+    var it = try db.entries(network, .{});
 
     var n: usize = 0;
-    while (try it.next()) |_| {
+    while (try it.next()) |entry| {
+        _ = try cache.decode(&db, entry, .{ .only = fields });
         n += 1;
     }
 

--- a/src/filter.zig
+++ b/src/filter.zig
@@ -29,6 +29,12 @@ pub fn Fields(comptime capacity: usize) type {
             errdefer allocator.free(buf);
 
             var f = try parse(buf, sep);
+            // Don't keep the buffer if no fields were parsed, e.g., empty string.
+            if (f.len == 0) {
+                allocator.free(buf);
+                return .{};
+            }
+
             f.buf = buf;
 
             return f;
@@ -107,6 +113,22 @@ test "append trims whitespace-only to no-op" {
     try f.append("\t");
     try f.append("\n");
     try std.testing.expectEqual(null, f.only());
+}
+
+test "parseAlloc empty string does not allocate" {
+    var f = try Fields(4).parseAlloc(std.testing.allocator, "", ',');
+    defer f.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(null, f.only());
+    try std.testing.expectEqual(null, f.buf);
+}
+
+test "parseAlloc whitespace-only does not allocate" {
+    var f = try Fields(4).parseAlloc(std.testing.allocator, "  ,  ,  ", ',');
+    defer f.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(null, f.only());
+    try std.testing.expectEqual(null, f.buf);
 }
 
 test "parseAlloc frees buffer on TooManyFields" {

--- a/src/maxminddb.zig
+++ b/src/maxminddb.zig
@@ -12,9 +12,9 @@ pub const geoip2 = @import("geoip2.zig");
 
 pub const Error = reader.ReadError || decoder.DecodeError;
 pub const Reader = reader.Reader;
-pub const Result = reader.Result;
 pub const Metadata = reader.Metadata;
-pub const Iterator = reader.Iterator;
+pub const ResultIterator = reader.ResultIterator;
+pub const EntryIterator = reader.EntryIterator;
 pub const Cache = reader.Cache;
 pub const Network = net.Network;
 pub const Map = collection.Map;
@@ -108,21 +108,105 @@ fn expectEqualMaps(
     keys: []const []const u8,
     values: []const []const u8,
 ) !void {
-    try std.testing.expectEqual(map.entries.len, keys.len);
+    try expectEqual(map.entries.len, keys.len);
 
     for (keys, values) |key, want_value| {
         const got_value = map.get(key) orelse {
             std.debug.print("map key=\"{s}\" was not found\n", .{key});
             return error.MapKeyNotFound;
         };
-        try std.testing.expectEqualStrings(want_value, got_value);
+        try expectEqualStrings(want_value, got_value);
     }
 }
 
 const allocator = std.testing.allocator;
+const expect = std.testing.expect;
 const expectEqual = std.testing.expectEqual;
 const expectEqualStrings = std.testing.expectEqualStrings;
 const expectEqualDeep = std.testing.expectEqualDeep;
+const expectError = std.testing.expectError;
+
+test "Metadata.decodeAs any.Value" {
+    var db = try Reader.mmap(
+        allocator,
+        "test-data/test-data/GeoLite2-City-Test.mmdb",
+        .{},
+    );
+    defer db.close();
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    const meta = try Metadata.decodeAs(any.Value, arena.allocator(), db.src);
+    try expectEqualStrings("GeoLite2-City", meta.get("database_type").?.string);
+    try expectEqual(@as(u16, 6), meta.get("ip_version").?.uint16);
+    try expectEqual(@as(u16, 2), meta.get("binary_format_major_version").?.uint16);
+}
+
+test "reject invalid metadata" {
+    try expectError(error.MetadataStartNotFound, Metadata.decode(allocator, "not a valid mmdb"));
+}
+
+test "Reader.open" {
+    var db = try Reader.open(
+        allocator,
+        "test-data/test-data/GeoLite2-City-Test.mmdb",
+        .{},
+    );
+    defer db.close();
+
+    const ip = try std.net.Address.parseIp("89.160.20.128", 0);
+    const got = (try db.lookup(geolite2.City, allocator, ip, .{})).?;
+    defer got.deinit();
+
+    try expectEqualStrings("SE", got.value.country.iso_code);
+}
+
+test "reject index bits > 24" {
+    try expectError(error.InvalidPrefixLen, Reader.mmap(
+        allocator,
+        "test-data/test-data/GeoLite2-City-Test.mmdb",
+        .{ .ipv4_index_first_n_bits = 25 },
+    ));
+}
+
+test "reject invalid prefix length" {
+    var db = try Reader.mmap(
+        allocator,
+        "test-data/test-data/GeoLite2-City-Test.mmdb",
+        .{},
+    );
+    defer db.close();
+
+    try expectError(error.InvalidPrefixLen, db.entries(.{
+        .ip = try std.net.Address.parseIp("0.0.0.0", 0),
+        .prefix_len = 33,
+    }, .{}));
+}
+
+test "reject invalid node count" {
+    try expectError(
+        error.CorruptedTree,
+        Reader.mmap(allocator, "test-data/test-data/GeoIP2-City-Test-Invalid-Node-Count.mmdb", .{}),
+    );
+}
+
+test "reject IPv6 on IPv4-only database" {
+    var db = try Reader.mmap(
+        allocator,
+        "test-data/test-data/MaxMind-DB-test-ipv4-32.mmdb",
+        .{},
+    );
+    defer db.close();
+
+    const network = try net.Network.parse("::/0");
+    const it = db.scan(any.Value, allocator, network, .{});
+    try expectError(error.IPv6AddressInIPv4Database, it);
+
+    const ip = try std.net.Address.parseIp("2001:db8::1", 0);
+    const result = db.lookup(any.Value, allocator, ip, .{});
+    try expectError(error.IPv6AddressInIPv4Database, result);
+}
 
 test DatabaseType {
     var db_type = DatabaseType.new("unknown db type!");
@@ -893,7 +977,7 @@ test "lookup with any.Value and field name filtering" {
     try expectEqual(null, got.value.get("location"));
 }
 
-test "decodeMetadata as any.Value" {
+test "IPv4 index matches non-indexed find" {
     var db = try Reader.mmap(
         allocator,
         "test-data/test-data/GeoLite2-City-Test.mmdb",
@@ -901,13 +985,33 @@ test "decodeMetadata as any.Value" {
     );
     defer db.close();
 
-    var arena = std.heap.ArenaAllocator.init(allocator);
-    defer arena.deinit();
+    var db_idx = try Reader.mmap(
+        allocator,
+        "test-data/test-data/GeoLite2-City-Test.mmdb",
+        .{ .ipv4_index_first_n_bits = 16 },
+    );
+    defer db_idx.close();
 
-    const meta = try Reader.decodeMetadata(any.Value, arena.allocator(), db.src);
-    try expectEqualStrings("GeoLite2-City", meta.get("database_type").?.string);
-    try expectEqual(@as(u16, 6), meta.get("ip_version").?.uint16);
-    try expectEqual(@as(u16, 2), meta.get("binary_format_major_version").?.uint16);
+    for ([_][]const u8{
+        "89.160.20.128",
+        "175.16.199.0",
+        "216.160.83.56",
+        "2001:218::",
+        "0.0.0.0",
+        "255.255.255.255",
+    }) |ip_str| {
+        const ip = try std.net.Address.parseIp(ip_str, 0);
+        const entry1 = try db.find(ip, .{});
+        const entry2 = try db_idx.find(ip, .{});
+
+        if (entry1) |e1| {
+            const e2 = entry2.?;
+            try expectEqual(e1.pointer, e2.pointer);
+            try expectEqual(e1.network.prefix_len, e2.network.prefix_len);
+        } else {
+            try expect(entry2 == null);
+        }
+    }
 }
 
 test "scan returns all networks" {
@@ -978,21 +1082,21 @@ test "scan yields record when start node is a data pointer" {
     }
 }
 
-test "reject IPv6 on IPv4-only database" {
+test "find skips empty records by default" {
     var db = try Reader.mmap(
         allocator,
-        "test-data/test-data/MaxMind-DB-test-ipv4-32.mmdb",
+        "test-data/test-data/GeoIP2-Anonymous-IP-Test.mmdb",
         .{},
     );
     defer db.close();
 
-    const network = try net.Network.parse("::/0");
-    const it = db.scan(any.Value, allocator, network, .{});
-    try std.testing.expectError(error.IPv6AddressInIPv4Database, it);
+    // 1.0.0.1 is in the db but its record is empty.
+    const ip = try std.net.Address.parseIp("1.0.0.1", 0);
 
-    const ip = try std.net.Address.parseIp("2001:db8::1", 0);
-    const result = db.lookup(any.Value, allocator, ip, .{});
-    try std.testing.expectError(error.IPv6AddressInIPv4Database, result);
+    // Empty records are skipped by default.
+    try expect(try db.find(ip, .{}) == null);
+
+    try expect((try db.find(ip, .{ .include_empty_values = true })) != null);
 }
 
 test "scan skips empty records" {
@@ -1013,7 +1117,7 @@ test "scan skips empty records" {
         while (try it.next()) |item| : (n += 1) {
             item.deinit();
         }
-        try std.testing.expectEqual(571, n);
+        try expectEqual(571, n);
     }
 
     // Only non-empty records.
@@ -1026,6 +1130,111 @@ test "scan skips empty records" {
         while (try it.next()) |item| : (n += 1) {
             item.deinit();
         }
-        try std.testing.expectEqual(8, n);
+        try expectEqual(8, n);
     }
+}
+
+test "cache hit returns same value" {
+    var db = try Reader.mmap(
+        allocator,
+        "test-data/test-data/GeoLite2-City-Test.mmdb",
+        .{},
+    );
+    defer db.close();
+
+    var cache = try Cache(geolite2.City).init(allocator, .{ .size = 4 });
+    defer cache.deinit();
+
+    const ip = try std.net.Address.parseIp("89.160.20.128", 0);
+    const entry = (try db.find(ip, .{})).?;
+
+    // Cache miss, decodes.
+    const v1 = try cache.decode(&db, entry, .{});
+    try expectEqualStrings("SE", v1.country.iso_code);
+
+    // Cache hit, same pointer.
+    const v2 = try cache.decode(&db, entry, .{});
+    try expectEqualStrings("SE", v2.country.iso_code);
+
+    const v3 = cache.get(entry.pointer).?;
+    try expectEqualStrings("SE", v3.country.iso_code);
+}
+
+test "cache eviction" {
+    var db = try Reader.mmap(
+        allocator,
+        "test-data/test-data/GeoLite2-City-Test.mmdb",
+        .{},
+    );
+    defer db.close();
+
+    // Size 1: every new entry evicts the previous one.
+    var cache = try Cache(geolite2.City).init(allocator, .{ .size = 1 });
+    defer cache.deinit();
+
+    const ip1 = try std.net.Address.parseIp("89.160.20.128", 0);
+    const entry1 = (try db.find(ip1, .{})).?;
+    _ = try cache.decode(&db, entry1, .{});
+    try expect(cache.get(entry1.pointer) != null);
+
+    const ip2 = try std.net.Address.parseIp("2001:218::", 0);
+    const entry2 = (try db.find(ip2, .{})).?;
+    _ = try cache.decode(&db, entry2, .{});
+
+    // entry1 is evicted.
+    try expect(cache.get(entry1.pointer) == null);
+    try expect(cache.get(entry2.pointer) != null);
+}
+
+test "cache ring buffer wrap-around" {
+    var db = try Reader.mmap(
+        allocator,
+        "test-data/test-data/GeoLite2-City-Test.mmdb",
+        .{},
+    );
+    defer db.close();
+
+    var cache = try Cache(geolite2.City).init(allocator, .{ .size = 2 });
+    defer cache.deinit();
+
+    const ip1 = try std.net.Address.parseIp("89.160.20.128", 0);
+    const ip2 = try std.net.Address.parseIp("2001:218::", 0);
+    const ip3 = try std.net.Address.parseIp("216.160.83.56", 0);
+
+    const entry1 = (try db.find(ip1, .{})).?;
+    const entry2 = (try db.find(ip2, .{})).?;
+    const entry3 = (try db.find(ip3, .{})).?;
+
+    _ = try cache.decode(&db, entry1, .{});
+    _ = try cache.decode(&db, entry2, .{});
+    // Cache is full now, so the next insert evicts entry1.
+    _ = try cache.decode(&db, entry3, .{});
+
+    try expect(cache.get(entry1.pointer) == null);
+    try expect(cache.get(entry2.pointer) != null);
+    try expect(cache.get(entry3.pointer) != null);
+}
+
+test "cache decode with field filtering" {
+    var db = try Reader.mmap(
+        allocator,
+        "test-data/test-data/GeoLite2-City-Test.mmdb",
+        .{},
+    );
+    defer db.close();
+
+    var cache = try Cache(geolite2.City).init(allocator, .{ .size = 4 });
+    defer cache.deinit();
+
+    const ip = try std.net.Address.parseIp("89.160.20.128", 0);
+    const entry = (try db.find(ip, .{})).?;
+
+    const v = try cache.decode(&db, entry, .{ .only = &.{"city"} });
+    try expectEqualStrings("Linköping", v.city.names.?.get("en").?);
+    // Country was not decoded.
+    try expectEqualStrings("", v.country.iso_code);
+}
+
+test "cache rejects size 0" {
+    try expectError(error.InvalidCacheSize, Cache(geolite2.City).init(allocator, .{ .size = 0 }));
 }

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -29,6 +29,37 @@ pub const Metadata = struct {
     languages: ?collection.Array([]const u8) = null,
     node_count: u32 = 0,
     record_size: u16 = 0,
+
+    // The last occurrence of this string in the file marks the end of the data section
+    // and the beginning of the metadata.
+    const start_marker = "\xAB\xCD\xEFMaxMind.com";
+
+    /// Decodes database metadata which is stored as a separate data section,
+    /// see https://maxmind.github.io/MaxMind-DB/#database-metadata.
+    pub fn decode(allocator: std.mem.Allocator, src: []const u8) !Metadata {
+        return decodeAs(Metadata, allocator, src);
+    }
+
+    /// Decodes metadata into an arbitrary type, e.g., any.Value.
+    pub fn decodeAs(T: type, allocator: std.mem.Allocator, src: []const u8) !T {
+        const metadata_start = try findMetadataStart(src);
+
+        var d = decoder.Decoder{
+            .src = src[metadata_start..],
+            .offset = 0,
+        };
+
+        return try d.decodeRecord(allocator, T, null);
+    }
+
+    fn findMetadataStart(src: []const u8) !usize {
+        var metadata_start = std.mem.lastIndexOf(u8, src, start_marker) orelse {
+            return ReadError.MetadataStartNotFound;
+        };
+        metadata_start += start_marker.len;
+
+        return metadata_start;
+    }
 };
 
 const data_section_separator_size = 16;
@@ -77,12 +108,10 @@ pub const Reader = struct {
         ipv4_index_first_n_bits: u8 = 0,
     };
 
-    /// A located entry in the database, returned by find().
-    /// Contains a pointer into the data section and the network that matched.
-    /// Pass it to decode() to get the record value.
-    pub const Entry = struct {
-        pointer: usize,
-        network: net.Network,
+    /// Options for find() and entries().
+    pub const EntryOptions = struct {
+        /// Include records that are empty maps. Skipped by default.
+        include_empty_values: bool = false,
     };
 
     /// Options for decoding records from the data section.
@@ -90,12 +119,43 @@ pub const Reader = struct {
         /// Decode only the specified top-level fields, e.g., &.{"city", "country"}.
         /// Null means decode all fields.
         only: ?[]const []const u8 = null,
+    };
+
+    /// Options for lookup() and scan().
+    pub const QueryOptions = struct {
+        /// Decode only the specified top-level fields, e.g., &.{"city", "country"}.
+        /// Null means decode all fields.
+        only: ?[]const []const u8 = null,
         /// Include records that are empty maps. Skipped by default.
         include_empty_values: bool = false,
     };
 
+    /// A located entry in the database, returned by find() and EntryIterator.next().
+    /// Contains a pointer into the data section and the network that matched.
+    /// Pass it to decode() or Cache.decode() to get the record value.
+    pub const Entry = struct {
+        /// Raw pointer into the data section as stored in the search tree.
+        /// Two entries with the same pointer reference the same data record.
+        /// Use as a cache key to avoid redundant decoding.
+        pointer: usize,
+        network: net.Network,
+    };
+
+    /// Result wraps a decoded value with an arena that owns all its allocations.
+    pub fn Result(comptime T: type) type {
+        return struct {
+            network: net.Network,
+            value: T,
+            arena: std.heap.ArenaAllocator,
+
+            pub fn deinit(self: @This()) void {
+                self.arena.deinit();
+            }
+        };
+    }
+
     fn init(arena: *std.heap.ArenaAllocator, src: []const u8, options: Options) !Reader {
-        const metadata = try decodeMetadata(Metadata, arena.allocator(), src);
+        const metadata = try Metadata.decode(arena.allocator(), src);
 
         switch (metadata.record_size) {
             24, 28, 32 => {},
@@ -182,6 +242,7 @@ pub const Reader = struct {
     }
 
     /// Looks up a value by an IP address.
+    /// Returns null when the IP address is not found or the record is empty.
     ///
     /// The returned Result owns an arena, so you should call deinit() to free it.
     pub fn lookup(
@@ -189,64 +250,21 @@ pub const Reader = struct {
         T: type,
         allocator: std.mem.Allocator,
         address: std.net.Address,
-        options: DecodeOptions,
+        options: QueryOptions,
     ) !?Result(T) {
-        const entry = try self.find(address) orelse return null;
-        return try self.decode(T, allocator, entry, options);
+        const entry = try self.find(
+            address,
+            .{ .include_empty_values = options.include_empty_values },
+        ) orelse return null;
+
+        return try self.decode(T, allocator, entry, .{ .only = options.only });
     }
 
-    /// Looks up a value by an IP address, using a cache.
-    ///
-    /// The cache owns the decoded memory, free it with cache.deinit().
-    pub fn lookupWithCache(
-        self: *Reader,
-        T: type,
-        cache: *Cache(T),
-        address: std.net.Address,
-        options: DecodeOptions,
-    ) !?Result(T) {
-        const entry = try self.find(address) orelse return null;
-
-        if (cache.get(entry.pointer)) |v| {
-            return .{
-                .network = entry.network,
-                .value = v,
-                .arena = null,
-                .pointer = entry.pointer,
-            };
-        }
-
-        if (!options.include_empty_values and try self.isEmptyRecord(entry.pointer)) {
-            return null;
-        }
-
-        var arena = std.heap.ArenaAllocator.init(cache.allocator);
-        errdefer arena.deinit();
-
-        const value = try self.resolveDataPointerAndDecode(
-            arena.allocator(),
-            T,
-            entry.pointer,
-            options.only,
-        );
-
-        cache.insert(.{
-            .pointer = entry.pointer,
-            .value = value,
-            .arena = arena,
-        });
-
-        return .{
-            .network = entry.network,
-            .value = value,
-            .arena = null,
-            .pointer = entry.pointer,
-        };
-    }
-
-    /// Finds an entry by an IP address (tree traversal only, no decoding).
-    /// Returns null if the IP address is not found.
-    pub fn find(self: *Reader, address: std.net.Address) !?Entry {
+    /// Finds an entry by an IP address (no decoding).
+    /// Returns null if the IP address is not found or the record is empty.
+    /// Empty records are skipped by default.
+    /// Use include_empty_values = true to return them.
+    pub fn find(self: *Reader, address: std.net.Address, options: EntryOptions) !?Entry {
         const ip = net.IP.init(address);
         if (ip.bitCount() == 128 and self.metadata.ip_version == 4) {
             return ReadError.IPv6AddressInIPv4Database;
@@ -265,6 +283,10 @@ pub const Reader = struct {
             return null;
         }
 
+        if (!options.include_empty_values and try self.isEmptyRecord(pointer)) {
+            return null;
+        }
+
         return .{
             .pointer = pointer,
             .network = ip.mask(prefix_len).network(prefix_len),
@@ -279,11 +301,7 @@ pub const Reader = struct {
         allocator: std.mem.Allocator,
         entry: Entry,
         options: DecodeOptions,
-    ) !?Result(T) {
-        if (!options.include_empty_values and try self.isEmptyRecord(entry.pointer)) {
-            return null;
-        }
-
+    ) !Result(T) {
         var arena = std.heap.ArenaAllocator.init(allocator);
         errdefer arena.deinit();
 
@@ -298,7 +316,6 @@ pub const Reader = struct {
             .network = entry.network,
             .value = value,
             .arena = arena,
-            .pointer = entry.pointer,
         };
     }
 
@@ -310,33 +327,24 @@ pub const Reader = struct {
         T: type,
         allocator: std.mem.Allocator,
         network: net.Network,
-        options: DecodeOptions,
-    ) !Iterator(T) {
-        return self.initIterator(allocator, T, network, null, options);
+        options: QueryOptions,
+    ) !ResultIterator(T) {
+        return .{
+            .it = try self.entries(
+                network,
+                .{ .include_empty_values = options.include_empty_values },
+            ),
+            .field_names = options.only,
+            .allocator = allocator,
+        };
     }
 
-    /// Scans networks within the given IP range, using a cache.
+    /// Iterates over entries (pointer + network) within the given IP range without decoding.
+    /// Use with decode() or Cache.decode() to control when decoding happens.
     ///
-    /// Adjacent networks often share the same record, so using a cache avoids redundant decoding.
-    /// The cache owns the decoded memory, free it with cache.deinit().
-    pub fn scanWithCache(
-        self: *Reader,
-        T: type,
-        cache: *Cache(T),
-        network: net.Network,
-        options: DecodeOptions,
-    ) !Iterator(T) {
-        return self.initIterator(cache.allocator, T, network, cache, options);
-    }
-
-    fn initIterator(
-        self: *Reader,
-        allocator: std.mem.Allocator,
-        T: type,
-        network: net.Network,
-        cache: ?*Cache(T),
-        options: DecodeOptions,
-    ) !Iterator(T) {
+    /// Empty records are skipped by default.
+    /// Use include_empty_values = true to yield them.
+    pub fn entries(self: *Reader, network: net.Network, options: EntryOptions) !EntryIterator {
         const prefix_len: usize = network.prefix_len;
         const ip_raw = net.IP.init(network.ip);
         const bit_count: usize = ip_raw.bitCount();
@@ -351,9 +359,9 @@ pub const Reader = struct {
         var node = self.startNode(bit_count);
         const node_count = self.metadata.node_count;
 
-        const ip_bytes = ip_raw.mask(prefix_len);
-        // Traverse down the tree to the level that matches the CIDR mark.
+        // Traverse down the tree to the level that matches the CIDR prefix.
         // Track depth as number of tree edges traversed (becomes the network prefix length).
+        const ip_bytes = ip_raw.mask(prefix_len);
         var depth: usize = 0;
         if (node < node_count) {
             while (depth < prefix_len) {
@@ -365,12 +373,9 @@ pub const Reader = struct {
             }
         }
 
-        var it = Iterator(T){
+        var it = EntryIterator{
             .reader = self,
             .node_count = node_count,
-            .allocator = allocator,
-            .cache = cache,
-            .field_names = options.only,
             .include_empty_values = options.include_empty_values,
         };
 
@@ -386,19 +391,6 @@ pub const Reader = struct {
         }
 
         return it;
-    }
-
-    /// Decodes database metadata which is stored as a separate data section,
-    /// see https://maxmind.github.io/MaxMind-DB/#database-metadata.
-    pub fn decodeMetadata(T: type, allocator: std.mem.Allocator, src: []const u8) !T {
-        const metadata_start = try findMetadataStart(src);
-
-        var d = decoder.Decoder{
-            .src = src[metadata_start..],
-            .offset = 0,
-        };
-
-        return try d.decodeRecord(allocator, T, null);
     }
 
     fn buildIPv4Index(self: *Reader) !void {
@@ -606,19 +598,6 @@ pub const Reader = struct {
             else => unreachable,
         };
     }
-
-    fn findMetadataStart(src: []const u8) !usize {
-        // The last occurrence of this string in the file marks the end of the data section
-        // and the beginning of the metadata.
-        const metadata_start_marker = "\xAB\xCD\xEFMaxMind.com";
-
-        var metadata_start = std.mem.lastIndexOf(u8, src, metadata_start_marker) orelse {
-            return ReadError.MetadataStartNotFound;
-        };
-        metadata_start += metadata_start_marker.len;
-
-        return metadata_start;
-    }
 };
 
 /// Ring buffer cache of recently decoded records.
@@ -642,6 +621,12 @@ pub fn Cache(comptime T: type) type {
             size: usize = 16,
         };
 
+        const Entry = struct {
+            pointer: usize,
+            value: T,
+            arena: std.heap.ArenaAllocator,
+        };
+
         pub fn init(allocator: std.mem.Allocator, options: Self.Options) !Self {
             if (options.size == 0) {
                 return error.InvalidCacheSize;
@@ -661,13 +646,8 @@ pub fn Cache(comptime T: type) type {
             self.allocator.free(self.entries);
         }
 
-        const Entry = struct {
-            pointer: usize,
-            value: T,
-            arena: std.heap.ArenaAllocator,
-        };
-
-        fn get(self: *Self, pointer: usize) ?T {
+        /// Returns a cached value for the given data pointer, or null on cache miss.
+        pub fn get(self: *Self, pointer: usize) ?T {
             for (self.entries[0..self.len]) |*e| {
                 if (e.pointer == pointer) {
                     return e.value;
@@ -675,6 +655,39 @@ pub fn Cache(comptime T: type) type {
             }
 
             return null;
+        }
+
+        /// Decodes an entry, using the cache to avoid redundant decoding.
+        /// Returns the cached value on hit, or decodes and caches on miss.
+        /// The cache owns the decoded memory.
+        /// The returned value is valid until the cache entry is evicted or cache.deinit() is called.
+        pub fn decode(
+            self: *Self,
+            db: *Reader,
+            entry: Reader.Entry,
+            options: Reader.DecodeOptions,
+        ) !T {
+            if (self.get(entry.pointer)) |v| {
+                return v;
+            }
+
+            var arena = std.heap.ArenaAllocator.init(self.allocator);
+            errdefer arena.deinit();
+
+            const value = try db.resolveDataPointerAndDecode(
+                arena.allocator(),
+                T,
+                entry.pointer,
+                options.only,
+            );
+
+            self.insert(.{
+                .pointer = entry.pointer,
+                .value = value,
+                .arena = arena,
+            });
+
+            return value;
         }
 
         fn insert(self: *Self, e: Entry) void {
@@ -693,161 +706,126 @@ pub fn Cache(comptime T: type) type {
     };
 }
 
-/// Result wraps a decoded value with an arena that owns all its allocations.
-/// When a cache is used, the cache owns the memory and arena is null.
-pub fn Result(comptime T: type) type {
+pub fn ResultIterator(T: type) type {
     return struct {
-        /// Raw pointer into the data section as stored in the search tree.
-        /// Two results with the same pointer reference the same data record.
-        /// This is the same value as Entry.pointer and Cache.Entry.pointer.
-        pointer: usize,
-        network: net.Network,
-        value: T,
-        arena: ?std.heap.ArenaAllocator,
-
-        pub fn deinit(self: @This()) void {
-            if (self.arena) |a| {
-                a.deinit();
-            }
-        }
-    };
-}
-
-const ScanNode = struct {
-    ip_bytes: net.IP,
-    prefix_len: usize,
-    node: usize,
-};
-
-pub fn Iterator(T: type) type {
-    return struct {
-        reader: *Reader,
-        node_count: usize,
-        // Fixed-capacity stack for DFS traversal.
-        stack: [max_stack_size]ScanNode = undefined,
-        stack_len: usize = 0,
-        allocator: std.mem.Allocator,
+        it: EntryIterator,
         field_names: ?[]const []const u8,
-        include_empty_values: bool,
-        cache: ?*Cache(T),
-
-        // Max depth is bit_count - prefix_len + 1 (129 for IPv6 /0).
-        const max_stack_size = 129;
-        const Self = @This();
+        allocator: std.mem.Allocator,
 
         /// Returns the next network and its value.
         ///
-        /// Without a cache the returned Result owns an arena, so you should call deinit() to free it.
-        /// Otherwise the cache owns the memory, free it with cache.deinit().
-        pub fn next(self: *Self) !?Result(T) {
-            while (self.pop()) |current| {
-                const reader = self.reader;
-                const bit_count = current.ip_bytes.bitCount();
+        /// The returned Result owns an arena, so you should call deinit() to free it.
+        pub fn next(self: *@This()) !?Reader.Result(T) {
+            const entry = try self.it.next() orelse return null;
 
-                // Skip networks that are aliases for the IPv4 network.
-                if (reader.ipv4_start != 0 and
-                    reader.ipv4_start == current.node and
-                    bit_count == 128 and
-                    !current.ip_bytes.isV4InV6())
-                {
-                    continue;
-                }
+            var arena = std.heap.ArenaAllocator.init(self.allocator);
+            errdefer arena.deinit();
 
-                // Found a data node to decode a record, e.g., geolite2.City.
-                if (current.node > self.node_count) {
-                    const ip_net = current.ip_bytes.network(current.prefix_len);
+            const value = try self.it.reader.resolveDataPointerAndDecode(
+                arena.allocator(),
+                T,
+                entry.pointer,
+                self.field_names,
+            );
 
-                    if (self.cache) |cache| {
-                        if (cache.get(current.node)) |v| {
-                            return .{
-                                .network = ip_net,
-                                .value = v,
-                                .arena = null,
-                                .pointer = current.node,
-                            };
-                        }
-                    }
-
-                    // Skip empty records (map with zero entries) unless requested.
-                    if (!self.include_empty_values and try reader.isEmptyRecord(current.node)) {
-                        continue;
-                    }
-
-                    var entry_arena = std.heap.ArenaAllocator.init(self.allocator);
-                    errdefer entry_arena.deinit();
-
-                    const value = try reader.resolveDataPointerAndDecode(
-                        entry_arena.allocator(),
-                        T,
-                        current.node,
-                        self.field_names,
-                    );
-
-                    if (self.cache) |cache| {
-                        cache.insert(.{
-                            .pointer = current.node,
-                            .value = value,
-                            .arena = entry_arena,
-                        });
-
-                        return .{
-                            .network = ip_net,
-                            .value = value,
-                            .arena = null,
-                            .pointer = current.node,
-                        };
-                    }
-
-                    return .{
-                        .network = ip_net,
-                        .value = value,
-                        .arena = entry_arena,
-                        .pointer = current.node,
-                    };
-                } else if (current.node < self.node_count) {
-                    // In order traversal of the children on the right (1-bit).
-                    var node = reader.readNode(current.node, 1);
-                    var right_ip_bytes = current.ip_bytes;
-
-                    if (current.prefix_len < bit_count) {
-                        const bit = current.prefix_len;
-                        switch (right_ip_bytes) {
-                            .v4 => |*b| b[bit >> 3] |= std.math.shl(u8, 1, (bit_count - bit - 1) % 8),
-                            .v6 => |*b| b[bit >> 3] |= std.math.shl(u8, 1, (bit_count - bit - 1) % 8),
-                        }
-                    }
-
-                    self.push(.{
-                        .node = node,
-                        .ip_bytes = right_ip_bytes,
-                        .prefix_len = current.prefix_len + 1,
-                    });
-
-                    // In order traversal of the children on the left (0-bit).
-                    node = reader.readNode(current.node, 0);
-                    self.push(.{
-                        .node = node,
-                        .ip_bytes = current.ip_bytes,
-                        .prefix_len = current.prefix_len + 1,
-                    });
-                }
-            }
-
-            return null;
-        }
-
-        fn push(self: *Self, node: ScanNode) void {
-            self.stack[self.stack_len] = node;
-            self.stack_len += 1;
-        }
-
-        fn pop(self: *Self) ?ScanNode {
-            if (self.stack_len == 0) {
-                return null;
-            }
-
-            self.stack_len -= 1;
-            return self.stack[self.stack_len];
+            return .{
+                .network = entry.network,
+                .value = value,
+                .arena = arena,
+            };
         }
     };
 }
+
+/// Iterates over entries (pointer + network) without decoding records.
+/// Empty records are skipped by default, see EntryOptions.
+/// Use Reader.decode() or Cache.decode() to decode individual entries.
+pub const EntryIterator = struct {
+    reader: *Reader,
+    node_count: usize,
+    stack: [max_stack_size]ScanNode = undefined,
+    stack_len: usize = 0,
+    include_empty_values: bool,
+
+    // Max depth is bit_count - prefix_len + 1 (129 for IPv6 /0).
+    const max_stack_size = 129;
+
+    const Self = @This();
+
+    const ScanNode = struct {
+        ip_bytes: net.IP,
+        prefix_len: usize,
+        node: usize,
+    };
+
+    /// Returns the next entry (pointer + network) or null when exhausted.
+    pub fn next(self: *Self) !?Reader.Entry {
+        while (self.pop()) |current| {
+            const reader = self.reader;
+            const bit_count = current.ip_bytes.bitCount();
+
+            // Skip networks that are aliases for the IPv4 network.
+            if (reader.ipv4_start != 0 and
+                reader.ipv4_start == current.node and
+                bit_count == 128 and
+                !current.ip_bytes.isV4InV6())
+            {
+                continue;
+            }
+
+            // Data pointer (> node_count) means this node holds a record.
+            if (current.node > self.node_count) {
+                if (!self.include_empty_values and try reader.isEmptyRecord(current.node)) {
+                    continue;
+                }
+
+                return .{
+                    .pointer = current.node,
+                    .network = current.ip_bytes.network(current.prefix_len),
+                };
+            } else if (current.node < self.node_count) {
+                // In order traversal of the children on the right (1-bit).
+                var node = reader.readNode(current.node, 1);
+                var right_ip_bytes = current.ip_bytes;
+
+                if (current.prefix_len < bit_count) {
+                    const bit = current.prefix_len;
+                    switch (right_ip_bytes) {
+                        .v4 => |*b| b[bit >> 3] |= std.math.shl(u8, 1, (bit_count - bit - 1) % 8),
+                        .v6 => |*b| b[bit >> 3] |= std.math.shl(u8, 1, (bit_count - bit - 1) % 8),
+                    }
+                }
+
+                self.push(.{
+                    .node = node,
+                    .ip_bytes = right_ip_bytes,
+                    .prefix_len = current.prefix_len + 1,
+                });
+
+                // In order traversal of the children on the left (0-bit).
+                node = reader.readNode(current.node, 0);
+                self.push(.{
+                    .node = node,
+                    .ip_bytes = current.ip_bytes,
+                    .prefix_len = current.prefix_len + 1,
+                });
+            }
+        }
+
+        return null;
+    }
+
+    fn push(self: *Self, node: ScanNode) void {
+        self.stack[self.stack_len] = node;
+        self.stack_len += 1;
+    }
+
+    fn pop(self: *Self) ?ScanNode {
+        if (self.stack_len == 0) {
+            return null;
+        }
+
+        self.stack_len -= 1;
+        return self.stack[self.stack_len];
+    }
+};


### PR DESCRIPTION
Removed `lookupWithCache` and `scanWithCache` in favour of `find()`, `decode()`, `entries()` primitives that are used by the `Cache`.